### PR TITLE
fix state_call

### DIFF
--- a/src/rpc/substrate/state.ts
+++ b/src/rpc/substrate/state.ts
@@ -39,7 +39,7 @@ const handlers: Handlers = {
     if (!block) {
       return []
     }
-    return block.call(method, data)
+    return (await block.call(method, data)).result
   },
   state_subscribeRuntimeVersion: async (context, _params, { subscribe }) => {
     let update = (_block: Block) => {}


### PR DESCRIPTION
## Change
previous shape is
```
{
  result: '0xxxx',
  storageDiff: ...
}
```
and we need the actual result.

## Test
previously `eth_call` throws `can't decode` error, after the fix it works 