### PR TITLE
override wasm before importing storage

### DIFF
--- a/packages/chopsticks/src/setup.ts
+++ b/packages/chopsticks/src/setup.ts
@@ -76,8 +76,10 @@ export const setup = async (argv: Config) => {
 
   if (argv.timestamp) await timeTravel(chain, argv.timestamp)
 
-  await importStorage(chain, argv['import-storage'])
+  // override wasm before importing storage, in case new pallets have been
+  // added that have storage imports
   await overrideWasm(chain, argv['wasm-override'])
+  await importStorage(chain, argv['import-storage'])
 
   return { chain, api, ws: provider }
 }


### PR DESCRIPTION
When new pallets are adding in the wasm-override, you can't override their storage currently. This pr swap the order of wasm overriding and storage overwriting