### PR TITLE
add VERBOSE_LOG env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Run node using config file
 npx @acala-network/chopsticks@latest -c acala
 ```
 
+## Environment Variables
+
+- `PORT`: Set port for Chopsticks to listen on, default is `8000`
+- `LOG_LEVEL`: Set log level, default is `info`. Available options: `trace`, `debug`, `info`, `warn`, `error`
+- `VERBOSE_LOG`: If set, do not truncating log messages
+
 ### Example configs can be found here
 
 - [acala](configs/acala.yml)

--- a/packages/chopsticks/src/logger.ts
+++ b/packages/chopsticks/src/logger.ts
@@ -10,15 +10,17 @@ export const defaultLogger = createLogger({
 const innerTruncate =
   (level = 0) =>
   (val: any) => {
+    const verboseLog = !!process.env.VERBOSE_LOG
+    const levelLimit = verboseLog ? 10 : 5
     if (val == null) {
       return val
     }
-    if (level > 5) {
+    if (level > levelLimit) {
       return '( Too Deep )'
     }
     switch (typeof val) {
       case 'string':
-        if (val.length > 66) {
+        if (val.length > 66 && !verboseLog) {
           return val.slice(0, 34) + '…' + val.slice(-32)
         } else {
           return val

--- a/packages/e2e/src/helper.ts
+++ b/packages/e2e/src/helper.ts
@@ -32,7 +32,7 @@ export type SetupOption = {
 
 export const env = {
   acala: {
-    endpoint: 'wss://acala-rpc-0.aca-api.network',
+    endpoint: 'wss://acala-rpc.aca-api.network',
     // 3,800,000
     blockHash: '0x0df086f32a9c3399f7fa158d3d77a1790830bd309134c5853718141c969299c7' as HexString,
   },

--- a/packages/e2e/src/system.test.ts
+++ b/packages/e2e/src/system.test.ts
@@ -9,7 +9,7 @@ describe('system rpc', () => {
 
   it('works', async () => {
     expect(await api.rpc.system.chain()).toMatch('Acala')
-    expect(await api.rpc.system.name()).toMatch('Acala Node')
+    expect(await api.rpc.system.name()).toMatch('Subway')
     expect(await api.rpc.system.version()).toBeInstanceOf(String)
     expect(await api.rpc.system.properties()).not.toBeNull()
     expectJson(await api.rpc.system.health()).toMatchObject({


### PR DESCRIPTION
add `VERBOSE_LOG` to avoid truncate log message so people can copy the whole XCM from logs