### PR TITLE
add unsafeBlockHeight

### DIFF
--- a/packages/chopsticks/src/plugins/new-block/index.ts
+++ b/packages/chopsticks/src/plugins/new-block/index.ts
@@ -2,7 +2,7 @@ import { Handler, ResponseError } from '../../rpc/shared'
 import { defaultLogger } from '../../logger'
 
 export const rpc: Handler = async (context, [param]) => {
-  const { count, to, hrmp, ump, dmp, transactions } = param || {}
+  const { count, to, hrmp, ump, dmp, transactions, unsafeBlockHeight } = param || {}
   const now = context.chain.head.number
   const diff = to ? to - now : count
   const finalCount = diff > 0 ? diff : 1
@@ -16,6 +16,7 @@ export const rpc: Handler = async (context, [param]) => {
         horizontalMessages: hrmp,
         upwardMessages: ump,
         downwardMessages: dmp,
+        unsafeBlockHeight: i === 0 ? unsafeBlockHeight : undefined,
       })
       .catch((error) => {
         throw new ResponseError(1, error.toString())

--- a/packages/core/src/blockchain/block-builder.ts
+++ b/packages/core/src/blockchain/block-builder.ts
@@ -151,7 +151,7 @@ export const buildBlock = async (
 ): Promise<[Block, HexString[]]> => {
   const registry = await head.registry
   const header = await newHeader(head, unsafeBlockHeight)
-  const newBlockNumber = unsafeBlockHeight ?? header.number.toNumber()
+  const newBlockNumber = header.number.toNumber()
 
   if (newBlockNumber < head.number) {
     throw new Error('unsafeBlockHeight is not allowed to be less than current block number')

--- a/packages/core/src/blockchain/txpool.ts
+++ b/packages/core/src/blockchain/txpool.ts
@@ -34,6 +34,7 @@ export interface BuildBlockParams {
   upwardMessages: Record<number, HexString[]>
   horizontalMessages: Record<number, HorizontalMessage[]>
   transactions: HexString[]
+  unsafeBlockHeight?: number
 }
 
 export class TxPool {
@@ -171,6 +172,7 @@ export class TxPool {
     const upwardMessages = params?.upwardMessages || { ...this.#ump }
     const downwardMessages = params?.downwardMessages || this.#dmp.splice(0)
     const horizontalMessages = params?.horizontalMessages || { ...this.#hrmp }
+    const unsafeBlockHeight = params?.unsafeBlockHeight
     if (!params?.upwardMessages) {
       for (const id of Object.keys(this.#ump)) {
         delete this.#ump[id]
@@ -186,6 +188,7 @@ export class TxPool {
       upwardMessages,
       downwardMessages,
       horizontalMessages,
+      unsafeBlockHeight,
     })
   }
 
@@ -231,6 +234,7 @@ export class TxPool {
       (extrinsic, error) => {
         this.event.emit(APPLY_EXTRINSIC_ERROR, [extrinsic, error])
       },
+      params.unsafeBlockHeight,
     )
     for (const extrinsic of pendingExtrinsics) {
       this.#pool.push({ extrinsic, signer: await this.#getSigner(extrinsic) })

--- a/packages/e2e/src/build-block.test.ts
+++ b/packages/e2e/src/build-block.test.ts
@@ -45,8 +45,9 @@ describe.each([
     const { chain, ws, teardown } = await setup()
     storage && (await ws.send('dev_setStorage', [storage]))
     const blockNumber = chain.head.number
-    await ws.send('dev_newBlock', [{ count: 2, unsafeBlockHeight: blockNumber + 100 }])
-    expect(chain.head.number).eq(blockNumber + 102)
+    const unsafeBlockHeight = blockNumber + 100
+    await ws.send('dev_newBlock', [{ count: 2, unsafeBlockHeight }])
+    expect(chain.head.number).eq(unsafeBlockHeight + 1)
     await teardown()
   })
 })

--- a/packages/e2e/src/build-block.test.ts
+++ b/packages/e2e/src/build-block.test.ts
@@ -40,4 +40,13 @@ describe.each([
     expect(chain.head.number).eq(blockNumber + 2)
     await teardown()
   })
+
+  it.runIf(process.env.CI)('build block using unsafeBlockHeight', async () => {
+    const { chain, ws, teardown } = await setup()
+    storage && (await ws.send('dev_setStorage', [storage]))
+    const blockNumber = chain.head.number
+    await ws.send('dev_newBlock', [{ count: 2, unsafeBlockHeight: blockNumber + 100 }])
+    expect(chain.head.number).eq(blockNumber + 102)
+    await teardown()
+  })
 })


### PR DESCRIPTION
closes: https://github.com/AcalaNetwork/chopsticks/issues/386

Update dev_newBlock to take a unsafeBlockHeight parameter to create new block at a specific block height.

- [x] add unsageBlockHeight
- [x] handle/fix failed tests
- [x] add e2e tests

---

**Manual test**
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "dev_newBlock",
    "params": [{
        "count": 1,
        "unsafeBlockHeight": 3000006
    }]
}
```


```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "dev_newBlock",
    "params": [{
        "count": 2,
        "unsafeBlockHeight": 11000006
    }]
}
```

<img src="https://github.com/AcalaNetwork/chopsticks/assets/32790369/6c240ecf-0462-4f9f-8757-0d43978c3248" width="600" />


