### PR TITLE
fix polkadot js got unknown error

### DIFF
--- a/packages/chopsticks/src/rpc/substrate/author.ts
+++ b/packages/chopsticks/src/rpc/substrate/author.ts
@@ -56,7 +56,7 @@ const handlers: Handlers = {
       })
       .catch((error: TransactionValidityError) => {
         logger.error({ error }, 'ExtrinsicFailed')
-        callback(error?.toJSON() ?? error)
+        callback(error?.toJSON?.() ?? error)
         done(id)
       })
     return id

--- a/packages/e2e/src/author.test.ts
+++ b/packages/e2e/src/author.test.ts
@@ -86,6 +86,12 @@ describe('author rpc', async () => {
     await expect(tx.send()).rejects.toThrow('1010: {"invalid":{"badProof":null}}')
   })
 
+  it('reject unsigned extrinsic', async () => {
+    const tx = api.tx.balances.transfer(bob.address, 100)
+
+    await expect(tx.send()).rejects.toThrow('1011: {"unknown":{"noUnsignedValidator":null}}')
+  })
+
   it('failed apply extirinsic', async () => {
     const finalized = defer<void>()
     const invalid = defer<string>()


### PR DESCRIPTION
closes #375 

Now the rpc's behaviour is the same as normal nodes, and both polkadot.js and chopstick won't crash when submit unsigned tx