### PR TITLE
fix deploy docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
 permissions:

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -6,7 +6,7 @@ export default defineConfig({
 	description: 'Chopsticks Types Documentation',
 	// Required for api-extractor markdown (https://github.com/vuejs/vitepress/pull/664)
 	markdown: { attrs: { disable: true } },
-	base: '/docs/',
+	base: '/chopsticks/docs/',
 	srcDir: 'docs-src',
 	outDir: 'dist/docs',
 	rewrites: {

--- a/packages/web-test/index.html
+++ b/packages/web-test/index.html
@@ -2,7 +2,7 @@
 <html>
 	<body>
 		<div style="position: absolute; top: 10px; right: 10px">
-			<a href="/docs">
+			<a href="/chopsticks/docs">
 				<button>Go to docs</button>
 			</a>
 		</div>


### PR DESCRIPTION
fix: route for docs in deployed version is wrong

tested on my fork: https://qiweiii.github.io/chopsticks/