### PR TITLE
refactor block builder

### DIFF
--- a/packages/core/src/blockchain/txpool.ts
+++ b/packages/core/src/blockchain/txpool.ts
@@ -234,8 +234,24 @@ export class TxPool {
       inherents,
       params.transactions,
       params.upwardMessages,
-      (extrinsic, error) => {
-        this.event.emit(APPLY_EXTRINSIC_ERROR, [extrinsic, error])
+      {
+        onApplyExtrinsicError: (extrinsic, error) => {
+          this.event.emit(APPLY_EXTRINSIC_ERROR, [extrinsic, error])
+        },
+        onPhaseApplied: logger.isLevelEnabled('trace')
+          ? (phase, resp) => {
+              switch (phase) {
+                case 'initialize':
+                  logger.trace(truncate(resp.storageDiff), 'Initialize block')
+                  break
+                case 'finalize':
+                  logger.trace(truncate(resp.storageDiff), 'Finalize block')
+                  break
+                default:
+                  logger.trace(truncate(resp.storageDiff), `Apply extrinsic ${phase}`)
+              }
+            }
+          : undefined,
       },
       params.unsafeBlockHeight,
     )


### PR DESCRIPTION
helpful for #295 and avoid redundant format when not on trace level logging