### PR TITLE
reduce default maxMemoryBlockCount

### DIFF
--- a/packages/core/src/blockchain/index.ts
+++ b/packages/core/src/blockchain/index.ts
@@ -111,7 +111,7 @@ export class Blockchain {
     runtimeLogLevel = 0,
     registeredTypes = {},
     offchainWorker = false,
-    maxMemoryBlockCount = 2000,
+    maxMemoryBlockCount = 500,
   }: Options) {
     this.api = api
     this.db = db


### PR DESCRIPTION
as mentioned here https://github.com/AcalaNetwork/chopsticks/issues/452#issuecomment-1776005992, limit memory block count for now to mitigate exceed max call stack size