### PR TITLE
fix: order of wasm and storage overrides

### DIFF
--- a/packages/chopsticks/src/context.ts
+++ b/packages/chopsticks/src/context.ts
@@ -84,8 +84,8 @@ export const setupContext = async (argv: Config, overrideParent = false) => {
 
   // override wasm before importing storage, in case new pallets have been
   // added that have storage imports
-  await overrideStorage(chain, argv['import-storage'], at)
   await overrideWasm(chain, argv['wasm-override'], at)
+  await overrideStorage(chain, argv['import-storage'], at)
 
   return { chain }
 }


### PR DESCRIPTION
In #352, the order of WASM and storage override order introduced in #199 was reverted. I suppose this happened by accident as the inline docs still state WASM override to have order priority. Moreover, it destroys the purpose of WASM override as new pallets cannot override storage.