### PR TITLE
fix randomness notFirstBlock undefined

### DIFF
--- a/packages/core/src/blockchain/block-builder.ts
+++ b/packages/core/src/blockchain/block-builder.ts
@@ -83,7 +83,7 @@ export const newHeader = async (head: Block, unsafeBlockHeight?: number) => {
       ...consensus.rest,
     ]
 
-    if (meta.query.randomness) {
+    if (meta.query.randomness?.notFirstBlock != undefined) {
       // TODO: shouldn't modify existing head
       // reset notFirstBlock so randomness will skip validation
       head.pushStorageLayer().set(compactHex(meta.query.randomness.notFirstBlock()), StorageValueKind.Deleted)

--- a/packages/core/src/blockchain/block-builder.ts
+++ b/packages/core/src/blockchain/block-builder.ts
@@ -83,7 +83,7 @@ export const newHeader = async (head: Block, unsafeBlockHeight?: number) => {
       ...consensus.rest,
     ]
 
-    if (meta.query.randomness?.notFirstBlock != undefined) {
+    if (meta.query.randomness?.notFirstBlock) {
       // TODO: shouldn't modify existing head
       // reset notFirstBlock so randomness will skip validation
       head.pushStorageLayer().set(compactHex(meta.query.randomness.notFirstBlock()), StorageValueKind.Deleted)


### PR DESCRIPTION
has error when using manta config:
- we have randomness, but don't have `notFirstBlock` yet.
```
root@VM-0-3-ubuntu:~/chopsticks# npx @acala-network/chopsticks@latest --config=configs/manta.yml
Unable to map [u8; 32] to a lookup index
[11:12:58.488] INFO (xcm/766006): Manta Parachain RPC listening on port 8000
/root/.npm/_npx/81ad9c881cb83600/node_modules/@acala-network/chopsticks-core/dist/cjs/blockchain/block-builder.js:116
            head.pushStorageLayer().set((0, _index.compactHex)(meta.query.randomness.notFirstBlock()), _storagelayer.StorageValueKind.Deleted);
                                                                                     ^

TypeError: meta.query.randomness.notFirstBlock is not a function
    at newHeader (/root/.npm/_npx/81ad9c881cb83600/node_modules/@acala-network/chopsticks-core/dist/cjs/blockchain/block-builder.js:116:86)
    at async buildBlock (/root/.npm/_npx/81ad9c881cb83600/node_modules/@acala-network/chopsticks-core/dist/cjs/blockchain/block-builder.js:169:20)
    at async TxPool.buildBlock (/root/.npm/_npx/81ad9c881cb83600/node_modules/@acala-network/chopsticks-core/dist/cjs/blockchain/txpool.js:313:43)
    at async TxPool.buildBlockIfNeeded (/root/.npm/_npx/81ad9c881cb83600/node_modules/@acala-network/chopsticks-core/dist/cjs/blockchain/txpool.js:295:9)
```