### PR TITLE
bind test account to Alice in Acala config

### DIFF
--- a/configs/acala.yml
+++ b/configs/acala.yml
@@ -72,3 +72,10 @@ import-storage:
       - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
       - 246gNkjCexYRsCpdjtVhz35sHjcb21jpqipzT9u4uwKV8iEE
       - 249LSvsEyxS4VpEJGg62yhYA7sHy1KcgGW6KzACBCLW1RsZF
+  EvmAccounts:
+    EvmAddresses:
+    - - - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+      - '0x75E480dB528101a381Ce68544611C169Ad7EB342'
+    Accounts:
+    - - - '0x75E480dB528101a381Ce68544611C169Ad7EB342'
+      - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY

--- a/configs/karura.yml
+++ b/configs/karura.yml
@@ -27,3 +27,10 @@ import-storage:
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
           - token: KSM
         - free: '10000000000000000000'
+  EvmAccounts:
+    EvmAddresses:
+    - - - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+      - '0x75E480dB528101a381Ce68544611C169Ad7EB342'
+    Accounts:
+    - - - '0x75E480dB528101a381Ce68544611C169Ad7EB342'
+      - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY


### PR DESCRIPTION
would it make sense to bind Alice to the test account we use in all tutorials by default, so we can test EVM+ out of box (currently we need to manually create a config for testing EVM+)