### PR TITLE
fix run block

### DIFF
--- a/packages/chopsticks/src/schema/index.ts
+++ b/packages/chopsticks/src/schema/index.ts
@@ -58,14 +58,12 @@ const getZodType = (option: ZodTypeAny) => {
       return 'number'
     case 'ZodBoolean':
       return 'boolean'
-    case 'ZodIntersection':
-      return 'string'
     default:
       break
-  }
-  if (option._def.innerType) {
-    return getZodType(option._def.innerType)
-  }
+    }
+    if (option._def.innerType ?? option._def.left) {
+      return getZodType(option._def.innerType ?? option._def.left)
+    }
   return undefined
 }
 

--- a/packages/chopsticks/src/schema/index.ts
+++ b/packages/chopsticks/src/schema/index.ts
@@ -58,6 +58,8 @@ const getZodType = (option: ZodTypeAny) => {
       return 'number'
     case 'ZodBoolean':
       return 'boolean'
+    case 'ZodIntersection':
+      return 'string'
     default:
       break
   }

--- a/packages/chopsticks/src/schema/index.ts
+++ b/packages/chopsticks/src/schema/index.ts
@@ -60,10 +60,10 @@ const getZodType = (option: ZodTypeAny) => {
       return 'boolean'
     default:
       break
-    }
-    if (option._def.innerType ?? option._def.left) {
-      return getZodType(option._def.innerType ?? option._def.left)
-    }
+  }
+  if (option._def.innerType ?? option._def.left) {
+    return getZodType(option._def.innerType ?? option._def.left)
+  }
   return undefined
 }
 

--- a/packages/chopsticks/src/schema/options.test.ts
+++ b/packages/chopsticks/src/schema/options.test.ts
@@ -14,7 +14,7 @@ it('get yargs options from zod schema', () => {
           "choices": undefined,
           "demandOption": false,
           "description": "Block hash or block number. Default to latest block",
-          "type": "number",
+          "type": "string",
         },
         "build-block-mode": {
           "choices": [
@@ -84,7 +84,7 @@ it('get yargs options from zod schema', () => {
           "choices": undefined,
           "demandOption": false,
           "description": "Resume from the specified block hash or block number in db. If true, it will resume from the latest block in db. Note this will override the block option",
-          "type": "number",
+          "type": "string",
         },
         "runtime-log-level": {
           "choices": undefined,

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,11 +1,13 @@
 import { pino } from 'pino'
 
-export const defaultLogger = pino({
+export const pinoLogger = pino({
   level: (typeof process === 'object' && process.env.LOG_LEVEL) || 'info',
   transport: {
     target: 'pino-pretty',
   },
 })
+
+export const defaultLogger = pinoLogger.child({ app: 'chopsticks' })
 
 const innerTruncate =
   (level = 0) =>

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -34,6 +34,8 @@ export type SetupOptions = {
 }
 
 export const setup = async (options: SetupOptions) => {
+  defaultLogger.debug(options, 'Setup options')
+
   let provider: ProviderInterface
   if (options.genesis) {
     provider = options.genesis


### PR DESCRIPTION
`yarn start run-block --block 0xa0cabfb6be38c2ea4468759e8f4182abfba3e35ac19cc36afe109e913d779b08 --endpoint=wss://rococo-coretime-rpc.polkadot.io` was broken due to the hex block hash is parsed as number