### PR TITLE
Fix `--preimage` storage value

### DIFF
--- a/packages/chopsticks/src/plugins/dry-run/dry-run-preimage.ts
+++ b/packages/chopsticks/src/plugins/dry-run/dry-run-preimage.ts
@@ -1,6 +1,6 @@
 import { HexString } from '@polkadot/util/types'
 import { blake2AsHex } from '@polkadot/util-crypto'
-import { compactAddLength, hexToU8a } from '@polkadot/util'
+import { compactAddLength, hexToU8a, u8aToHex } from '@polkadot/util'
 
 import { Block, newHeader, runTask, setStorage, taskHandler } from '@acala-network/chopsticks-core'
 import { DryRunSchemaType } from './index.js'
@@ -24,7 +24,7 @@ export const dryRunPreimage = async (argv: DryRunSchemaType) => {
 
   await setStorage(context.chain, {
     Preimage: {
-      PreimageFor: [[[[hash, data.byteLength]], compactAddLength(data)]],
+      PreimageFor: [[[[hash, data.byteLength]], u8aToHex(compactAddLength(data))]],
       StatusFor: [
         [
           [hash],


### PR DESCRIPTION
Related to: https://github.com/AcalaNetwork/chopsticks/issues/630 and https://github.com/paritytech/polkadot-sdk/issues/3522

I'm trying to simulate some bridge-initialization calls using chopsticks. I used the code found in `dry-run-preimage.ts` as an example for crafting my own `dev_setStorage` call for simulating an approved preimage. The initial version didn't work (it was failing with `CallUnavailable`) and it took quite a while to find the solution presented in #630. Not sure if this is the best fix, but I think it would bring value to have this fixed. At least it would have saved a lot of time for me.