### PR TITLE
Fix `HRMP` messages delivery for unregistered channels

### DIFF
--- a/packages/chopsticks/src/cli.ts
+++ b/packages/chopsticks/src/cli.ts
@@ -64,7 +64,7 @@ const commands = yargs(hideBin(process.argv))
         parachains.push(chain)
       }
 
-      let relaychain: Blockchain | undefined;
+      let relaychain: Blockchain | undefined
 
       if (argv.relaychain) {
         const { chain: rc } = await setupWithServer(await fetchConfig(argv.relaychain))

--- a/packages/chopsticks/src/cli.ts
+++ b/packages/chopsticks/src/cli.ts
@@ -64,12 +64,18 @@ const commands = yargs(hideBin(process.argv))
         parachains.push(chain)
       }
 
-      if (parachains.length > 1) {
-        await connectParachains(parachains)
-      }
+      let relaychain: Blockchain | undefined;
 
       if (argv.relaychain) {
-        const { chain: relaychain } = await setupWithServer(await fetchConfig(argv.relaychain))
+        const { chain: rc } = await setupWithServer(await fetchConfig(argv.relaychain))
+        relaychain = rc
+      }
+
+      if (parachains.length > 1) {
+        await connectParachains(parachains, relaychain)
+      }
+
+      if (relaychain) {
         for (const parachain of parachains) {
           await connectVertical(relaychain, parachain)
         }

--- a/packages/chopsticks/src/plugins/dry-run/dry-run-preimage.ts
+++ b/packages/chopsticks/src/plugins/dry-run/dry-run-preimage.ts
@@ -77,6 +77,7 @@ export const dryRunPreimage = async (argv: DryRunSchemaType) => {
       downwardMessages: [],
       upwardMessages: [],
       horizontalMessages: {},
+      hrmpChannels: {},
     })
     if (extrinsics.length === 0) continue
     calls.push(['BlockBuilder_apply_extrinsic', extrinsics])

--- a/packages/core/src/blockchain/index.ts
+++ b/packages/core/src/blockchain/index.ts
@@ -11,7 +11,7 @@ import type { TransactionValidity } from '@polkadot/types/interfaces/txqueue'
 
 import { Api } from '../api.js'
 import { Block } from './block.js'
-import { BuildBlockMode, BuildBlockParams, DownwardMessage, HorizontalMessage, TxPool } from './txpool.js'
+import { BuildBlockMode, BuildBlockParams, DownwardMessage, HorizontalMessage, HrmpChannels, TxPool } from './txpool.js'
 import { Database } from '../database.js'
 import { HeadState } from './head-state.js'
 import { InherentProvider } from './inherent/index.js'
@@ -391,6 +391,12 @@ export class Blockchain {
     logger.debug({ id, hrmp }, 'submitHorizontalMessages')
   }
 
+  openHrmpChannels(id: number, channels: HrmpChannels) {
+    this.#txpool.openHrmpChannels(id, channels)
+
+    logger.debug({ id, channels }, 'openHrmpChannels')
+  }
+
   /**
    * Build a new block with optional params. Use this when you don't have all the {@link BuildBlockParams}
    */
@@ -432,6 +438,7 @@ export class Blockchain {
       downwardMessages: [],
       upwardMessages: [],
       horizontalMessages: {},
+      hrmpChannels: {},
     }
     const { result, storageDiff } = await dryRunExtrinsic(head, this.#inherentProviders, extrinsic, params)
     const outcome = registry.createType<ApplyExtrinsicResult>('ApplyExtrinsicResult', result)
@@ -456,6 +463,7 @@ export class Blockchain {
       downwardMessages: [],
       upwardMessages: [],
       horizontalMessages: hrmp,
+      hrmpChannels: {},
     }
     return dryRunInherents(head, this.#inherentProviders, params)
   }
@@ -475,6 +483,7 @@ export class Blockchain {
       downwardMessages: dmp,
       upwardMessages: [],
       horizontalMessages: {},
+      hrmpChannels: {},
     }
     return dryRunInherents(head, this.#inherentProviders, params)
   }
@@ -516,6 +525,7 @@ export class Blockchain {
       downwardMessages: [],
       upwardMessages: [],
       horizontalMessages: {},
+      hrmpChannels: {},
     }
     return dryRunInherents(head, this.#inherentProviders, params)
   }

--- a/packages/core/src/blockchain/inherent/parachain/validation-data.ts
+++ b/packages/core/src/blockchain/inherent/parachain/validation-data.ts
@@ -116,7 +116,7 @@ export class SetValidationData implements InherentProvider {
       .divn(3000) // relaychain min period
       .toNumber()
 
-    slotIncrease = slotIncrease === 0 ? 1 : slotIncrease;
+    slotIncrease = slotIncrease === 0 ? 1 : slotIncrease
 
     for (const key of Object.values(WELL_KNOWN_KEYS)) {
       if (key === WELL_KNOWN_KEYS.CURRENT_SLOT) {
@@ -125,14 +125,14 @@ export class SetValidationData implements InherentProvider {
           ? meta.registry.createType<Slot>('Slot', hexToU8a(decoded[key])).toNumber()
           : (await getCurrentSlot(parent.chain)) * slotIncrease
 
-        let newSlot: number;
+        let newSlot: number
 
         // Genesis with async backing
         if (parent.number === 0 && Number(minPeriod) < 6000) {
           const slotDuration = await getSlotDuration(parent.chain)
           const currentTimestamp = await getCurrentTimestamp(parent.chain)
-          newSlot = Math.ceil(Number(currentTimestamp)/slotDuration)
-        } else{
+          newSlot = Math.ceil(Number(currentTimestamp) / slotDuration)
+        } else {
           newSlot = relayCurrentSlot + slotIncrease
         }
         const slot = meta.registry.createType<Slot>('Slot', newSlot)
@@ -149,7 +149,7 @@ export class SetValidationData implements InherentProvider {
     const hrmpEgressChannels = meta.registry.createType('Vec<u32>', hexToU8a(decoded[hrmpEgressChannelIndexKey]))
 
     params.hrmpChannels[Number(paraId)]?.egress.forEach((receiver) => {
-      const receiverId = meta.registry.createType('u32',  Number(receiver))
+      const receiverId = meta.registry.createType('u32', Number(receiver))
       // order is important
       if (!hrmpEgressChannels.some((x) => x.eq(receiverId))) {
         const idx = _.sortedIndexBy(hrmpEgressChannels, receiverId, (x) => x.toNumber())
@@ -158,7 +158,7 @@ export class SetValidationData implements InherentProvider {
     })
 
     params.hrmpChannels[Number(paraId)]?.ingress.forEach((sender) => {
-      const senderId = meta.registry.createType('u32',  Number(sender))
+      const senderId = meta.registry.createType('u32', Number(sender))
       // order is important
       if (!hrmpIngressChannels.some((x) => x.eq(senderId))) {
         const idx = _.sortedIndexBy(hrmpIngressChannels, senderId, (x) => x.toNumber())

--- a/packages/core/src/xcm/horizontal.ts
+++ b/packages/core/src/xcm/horizontal.ts
@@ -46,17 +46,15 @@ export const connectHorizontal = async (parachains: Record<number, Blockchain>, 
 
         for (const [key, value] of pairs) {
           if (key === hrmpEgressChannelsIndex) {
-            hrmpEgressChannels = meta.registry.createType('Vec<u32>', hexToU8a(value))
-            .toJSON() as number[]
+            hrmpEgressChannels = meta.registry.createType('Vec<u32>', hexToU8a(value)).toJSON() as number[]
           } else if (key === hrmpIngressChannelsIndex) {
-            hrmpIngressChannels = meta.registry.createType('Vec<u32>', hexToU8a(value))
-            .toJSON() as number[]
+            hrmpIngressChannels = meta.registry.createType('Vec<u32>', hexToU8a(value)).toJSON() as number[]
           } else {
             return
           }
         }
 
-        xcmLogger.info({ paraId: Number(id) , egress: hrmpEgressChannels, ingress: hrmpIngressChannels }, 'hrmpChannels')
+        xcmLogger.info({ paraId: Number(id), egress: hrmpEgressChannels, ingress: hrmpIngressChannels }, 'hrmpChannels')
         chain.openHrmpChannels(Number(id), { egress: hrmpEgressChannels, ingress: hrmpIngressChannels })
       })
     }

--- a/packages/core/src/xcm/index.ts
+++ b/packages/core/src/xcm/index.ts
@@ -15,7 +15,7 @@ export const connectVertical = async (relaychain: Blockchain, parachain: Blockch
   )
 }
 
-export const connectParachains = async (parachains: Blockchain[]) => {
+export const connectParachains = async (parachains: Blockchain[], relaychain: Blockchain | undefined) => {
   const list: Record<number, Blockchain> = {}
 
   for (const chain of parachains) {
@@ -23,7 +23,7 @@ export const connectParachains = async (parachains: Blockchain[]) => {
     list[paraId.toNumber()] = chain
   }
 
-  await connectHorizontal(list)
+  await connectHorizontal(list, relaychain)
 
   xcmLogger.info(`Connected parachains [${Object.keys(list)}]`)
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -140,7 +140,7 @@ export const setupNetworks = async (networkOptions: Partial<Record<string, Confi
 
   const parachainList = Object.values(parachains).map((i) => i.chain)
   if (parachainList.length > 0) {
-    await connectParachains(parachainList)
+    await connectParachains(parachainList, relaychain?.chain)
   }
 
   if (wasmOverriden) {


### PR DESCRIPTION
This PR aims to fix HRMP messages delivery for unregistered HRMP channels. Previous solution of opening channels on the fly did not really work, as it required at least one of the Parachains with an open `EgressChannel`.

Now, HRMP channels are expected to be opened in the Relay Chain.

Additionally, there are also a couple of improvements foreseen in upcoming runtime changes:
- Fixing slot calculation for genesis with async backing
- Producing an extra block for DMP messages in case `MessageQueue` is used