### PR TITLE
Tanssi: Add support for `expectedBlockTime` of async backing pallet

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -144,5 +144,7 @@ export const getSlotDuration = async (chain: Blockchain) => {
     ? (meta.consts.babe.expectedBlockTime as any as BN).toNumber()
     : meta.query.aura
       ? getAuraSlotDuration(await chain.head.wasm)
-      : 12_000
+      : meta.consts.asyncBacking
+        ? (meta.consts.asyncBacking.expectedBlockTime as any as BN).toNumber()
+        : 12_000
 }


### PR DESCRIPTION
### Motivation

At Tanssi, we are working on adding support for asynchronous backing. Of course, this involves changing the slot duration from `12000` milliseconds to `6000` milliseconds.

While trying to test some features using chopsticks (like upgrading the on-chain runtime), we are encountering the issue that the network doesn't even start. The reason for this is that at the moment of fetching the slot duration inside `getSlotDuration` function, Tanssi chain metadata doesn't match with any of the current statements.

As Tanssi doesn't make use of Aura or Babe pallets directly, but instead of the AsyncBacking pallet ([implemented](https://github.com/Moonsong-Labs/moonkit/blob/main/pallets/async-backing/src/lib.rs) in Moonkit repo), it would be nice to have an extra statement that checks for the existence of this pallet and thus retrieve the correct slot duration from there.