### PR TITLE
Fix Collective Pallets Moonbeam

### DIFF
--- a/configs/moonbase-alpha.yml
+++ b/configs/moonbase-alpha.yml
@@ -12,9 +12,7 @@ import-storage:
         - providers: 1
           data:
             free: "100000000000000000000000"
-  TechCommitteeCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  CouncilCollective:
+  OpenTechCommitteeCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
   TreasuryCouncilCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]

--- a/configs/moonbeam.yml
+++ b/configs/moonbeam.yml
@@ -12,9 +12,7 @@ import-storage:
         - providers: 1
           data:
             free: "100000000000000000000000"
-  TechCommitteeCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  CouncilCollective:
+  OpenTechCommitteeCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
   TreasuryCouncilCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]

--- a/configs/moonriver.yml
+++ b/configs/moonriver.yml
@@ -12,9 +12,7 @@ import-storage:
         - providers: 1
           data:
             free: "100000000000000000000000"
-  TechCommitteeCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  CouncilCollective:
+  OpenTechCommitteeCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
   TreasuryCouncilCollective:
     Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]


### PR DESCRIPTION
Moonbeam, Moonriver and Moonbase Alpha no longer use some of the collective pallets in favor of other collectives