### PR TITLE
`runtime-log-level: 5` for most chains

### DIFF
--- a/configs/acala.yml
+++ b/configs/acala.yml
@@ -4,6 +4,7 @@ endpoint:
 mock-signature-host: true
 block: ${env.ACALA_BLOCK_NUMBER}
 db: ./db.sqlite
+runtime-log-level: 5
 
 import-storage:
   Sudo:

--- a/configs/astar.yml
+++ b/configs/astar.yml
@@ -2,6 +2,7 @@ endpoint: wss://astar.api.onfinality.io/public-ws
 mock-signature-host: true
 block: ${env.ASTAR_BLOCK_NUMBER}
 db: ./db.sqlite
+runtime-log-level: 5
 
 import-storage:
   Sudo:

--- a/configs/basilisk.yml
+++ b/configs/basilisk.yml
@@ -2,6 +2,8 @@ endpoint: wss://basilisk-rpc.dwellir.com
 mock-signature-host: true
 block: ${env.BASILISK_BLOCK_NUMBER}
 db: ./db.sqlite
+runtime-log-level: 5
+
 
 import-storage:
   System:

--- a/configs/bifrost.yml
+++ b/configs/bifrost.yml
@@ -2,6 +2,7 @@ endpoint: wss://bifrost-parachain.api.onfinality.io/public-ws
 mock-signature-host: true
 block: ${env.BIFROST_BLOCK_NUMBER}
 db: ./db.sqlite
+runtime-log-level: 5
 
 import-storage:
   System:

--- a/configs/hydradx.yml
+++ b/configs/hydradx.yml
@@ -2,6 +2,7 @@ endpoint: wss://hydradx-rpc.dwellir.com
 mock-signature-host: true
 block: ${env.HYDRADX_BLOCK_NUMBER}
 db: ./hydradx.db.sqlite
+runtime-log-level: 5
 # wasm-override: hydradx_runtime.compact.compressed.wasm
 
 import-storage:

--- a/configs/interlay.yml
+++ b/configs/interlay.yml
@@ -2,6 +2,7 @@ endpoint: wss://rpc-interlay.luckyfriday.io/
 mock-signature-host: true
 block: ${env.INTERLAY_BLOCK_NUMBER}
 db: ./interlay.db.sqlite
+runtime-log-level: 5
 # wasm-override: interlay_runtime.compact.compressed.wasm
 
 import-storage:

--- a/configs/karura.yml
+++ b/configs/karura.yml
@@ -2,6 +2,7 @@ endpoint: wss://karura-rpc.aca-api.network
 mock-signature-host: true
 block: ${env.KARURA_BLOCK_NUMBER}
 db: ./db.sqlite
+runtime-log-level: 5
 
 import-storage:
   Sudo:

--- a/configs/khala.yml
+++ b/configs/khala.yml
@@ -5,6 +5,7 @@ endpoint:
 mock-signature-host: true
 block: ${env.KHALA_BLOCK_NUMBER}
 db: ./khala.db.sqlite
+runtime-log-level: 5
 # wasm-override: thala_parachain_runtime.compact.compressed.wasm
 
 import-storage:

--- a/configs/phala.yml
+++ b/configs/phala.yml
@@ -5,6 +5,7 @@ endpoint:
 mock-signature-host: true
 block: ${env.PHALA_BLOCK_NUMBER}
 db: ./phala.db.sqlite
+runtime-log-level: 5
 # wasm-override: thala_parachain_runtime.compact.compressed.wasm
 
 import-storage:

--- a/configs/polkadot.yml
+++ b/configs/polkadot.yml
@@ -4,6 +4,7 @@ endpoint:
 mock-signature-host: true
 block: ${env.POLKADOT_BLOCK_NUMBER}
 db: ./db.sqlite
+runtime-log-level: 5
 # wasm-override: polkadot_runtime.compact.compressed.wasm
 
 import-storage:


### PR DESCRIPTION
This was very valuable when debugging XCM error messages. It was nice that it was the default already for Centrifuge, so seems like a good idea to make it the default for several other chains as well.