### PR TITLE
separate Bifrost-Polkadot config from KSM Bifrost-Polkadot

### DIFF
--- a/configs/bifrost-polkadot.yml
+++ b/configs/bifrost-polkadot.yml
@@ -1,4 +1,4 @@
-endpoint: wss://bifrost-parachain.api.onfinality.io/public-ws
+endpoint: wss://bifrost-polkadot.api.onfinality.io/public-ws
 mock-signature-host: true
 block: ${env.BIFROST_BLOCK_NUMBER}
 db: ./db.sqlite
@@ -19,55 +19,90 @@ import-storage:
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: ASG
+          - Token2: 0 # DOT
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: BNC
+          - Token2: 1 # GLMR
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: KUSD
+          - Token2: 2 # USDT
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: DOT
+          - Token2: 3 # ASTR
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: KSM
+          - Token2: 4 # FIL  (Filecoin)
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: ETH
+          - Token2: 5 # USDC
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: KAR
+          - Token2: 6 # interBTC (iBTC) from Interlay
+        - free: '2100000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - Token2: 7 # INTR
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: ZLK
+          - Token2: 8 # MANTA
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: PHA
+          - Token2: 9 # BNCs (inscriptions on BNC)
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: RMRK
+          - Token2: 10 # PINK
         - free: '100000000000000000000000000000'
       -
         -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          - Native: MOVR
+          - Token2: 11 # DED
+        - free: '100000000000000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - VToken2: 0 # vDOT
+        - free: '100000000000000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - VToken2: 1 # vGLMR
+        - free: '100000000000000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - VToken2: 3 # vASTR
+        - free: '100000000000000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - VToken2: 4 # vFIL
+        - free: '100000000000000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - VToken2: 8 # vMANTA
+        - free: '100000000000000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - VSToken2: 0 # vsDOT
         - free: '100000000000000000000000000000'

--- a/configs/bifrost-polkadot.yml
+++ b/configs/bifrost-polkadot.yml
@@ -1,6 +1,6 @@
 endpoint: wss://bifrost-polkadot.api.onfinality.io/public-ws
 mock-signature-host: true
-block: ${env.BIFROST_BLOCK_NUMBER}
+block: ${env.BIFROSTPOLKADOT_BLOCK_NUMBER}
 db: ./db.sqlite
 runtime-log-level: 5
 


### PR DESCRIPTION
Bifrost Kusama and Bifrost Polkadot chains need different configs. Previously, running with `bifrost.yml` would emulate Kusama Bifrost parachain, but had token config for Polkadot tokens. Therefore split them and clean that up.

Tested by running Chopsticks and using p.js to verify tokens in the account.