### PR TITLE
make json-rpc server id handling spec-compliant

### DIFF
--- a/packages/chopsticks/src/server.ts
+++ b/packages/chopsticks/src/server.ts
@@ -93,14 +93,13 @@ export const createServer = async (handler: Handler, port: number) => {
 
   const safeHandleRequest = async (request: z.infer<typeof singleRequest>) => {
     try {
-      const result = handler(request, emptySubscriptionManager)
+      const result = await handler(request, emptySubscriptionManager)
       return request.id === undefined ? undefined : { id: request.id, jsonrpc: '2.0', result }
     } catch (err: any) {
       return {
         jsonrpc: '2.0',
         id: request.id,
         error: {
-          code: -32603,
           message: err.message,
         },
       }
@@ -144,7 +143,6 @@ export const createServer = async (handler: Handler, port: number) => {
           jsonrpc: '2.0',
           id: null,
           error: {
-            code: -32700,
             message: err.message,
           },
         }),

--- a/packages/chopsticks/src/server.ts
+++ b/packages/chopsticks/src/server.ts
@@ -9,7 +9,7 @@ const httpLogger = defaultLogger.child({ name: 'http' })
 const wsLogger = defaultLogger.child({ name: 'ws' })
 
 const singleRequest = z.object({
-  id: z.number(),
+  id: z.optional(z.union([z.number().int(), z.string(), z.null()])),
   jsonrpc: z.literal('2.0'),
   method: z.string(),
   params: z.array(z.any()).default([]),
@@ -91,6 +91,22 @@ export const createServer = async (handler: Handler, port: number) => {
     },
   }
 
+  const safeHandleRequest = async (request: z.infer<typeof singleRequest>) => {
+    try {
+      const result = handler(request, emptySubscriptionManager)
+      return request.id === undefined ? undefined : { id: request.id, jsonrpc: '2.0', result }
+    } catch (err: any) {
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        error: {
+          code: -32603,
+          message: err.message,
+        },
+      }
+    }
+  }
+
   const server = http.createServer(async (req, res) => {
     if (req.method === 'OPTIONS') {
       return respond(res)
@@ -112,25 +128,23 @@ export const createServer = async (handler: Handler, port: number) => {
 
       let response: any
       if (Array.isArray(parsed.data)) {
-        response = await Promise.all(
-          parsed.data.map((req) => {
-            const result = handler(req, emptySubscriptionManager)
-            return { id: req.id, jsonrpc: '2.0', result }
-          }),
-        )
+        response = await Promise.all(parsed.data.map(safeHandleRequest))
+        response = response.filter((r) => r !== undefined)
       } else {
-        const result = await handler(parsed.data, emptySubscriptionManager)
-        response = { id: parsed.data.id, jsonrpc: '2.0', result }
+        response = await safeHandleRequest(parsed.data)
       }
 
-      respond(res, JSON.stringify(response))
+      if (response !== undefined) {
+        respond(res, JSON.stringify(response))
+      }
     } catch (err: any) {
       respond(
         res,
         JSON.stringify({
           jsonrpc: '2.0',
-          id: 1,
+          id: null,
           error: {
+            code: -32700,
             message: err.message,
           },
         }),

--- a/packages/e2e/src/http.test.ts
+++ b/packages/e2e/src/http.test.ts
@@ -115,5 +115,23 @@ describe('http.server', () => {
         },
       ).end(body)
     }
+
+    {
+      // Accepts string ids
+      const id = 'lorem ipsum dolor sit amet'
+      const res = await fetch(`http://localhost:${port}`, {
+        method: 'POST',
+        body: JSON.stringify({ id, jsonrpc: '2.0', method: 'chain_getBlockHash', params: [] }),
+      })
+      expect(await res.json()).toMatchInlineSnapshot(
+        `
+        {
+          "id": "${id}",
+          "jsonrpc": "2.0",
+          "result": "0x0df086f32a9c3399f7fa158d3d77a1790830bd309134c5853718141c969299c7",
+        }
+      `,
+      )
+    }
   })
 })

--- a/packages/e2e/src/http.test.ts
+++ b/packages/e2e/src/http.test.ts
@@ -106,7 +106,7 @@ describe('http.server', () => {
               "error": {
                 "message": "Only POST method is supported",
               },
-              "id": 1,
+              "id": null,
               "jsonrpc": "2.0",
             }
           `,


### PR DESCRIPTION
Initial bit of work for #801 

This makes id handling spec-compliant by [JSON-RPC 2.0](https://www.jsonrpc.org/specification). Notable changes:

- The `id` can now be parsed as a number, string, null or undefined
- If the `id` is a number, it must be an integer.
- The `id` from error responses is now correct:
  - If it was while parsing the message, then it's `null`.
  - If it was while handling a request, then it's the same request id as that request.
- It handles notifications correctly: if the `id` is undefined, no response is returned. 

~~I couldn't find a good place to add tests for these cases - please let me know if you want me to add some, or if you need anything else.~~
I could find the test file, `e2e/src/http.test.ts`
