### PR TITLE
support async transition

### DIFF
--- a/packages/core/src/blockchain/inherent/parachain/validation-data.ts
+++ b/packages/core/src/blockchain/inherent/parachain/validation-data.ts
@@ -113,7 +113,7 @@ export class SetValidationData implements InherentProvider {
       extrinsic.relayChainState.trieNodes,
     )
 
-    const slotIncrease = Math.max(
+    const relaySlotIncrease = Math.max(
       1, // min
       (meta.consts.timestamp?.minimumPeriod as any as BN) // legacy
         ?.divn(3000) // relaychain min period
@@ -129,8 +129,8 @@ export class SetValidationData implements InherentProvider {
         // increment current slot
         const relayCurrentSlot = decoded[key]
           ? meta.registry.createType<Slot>('Slot', hexToU8a(decoded[key])).toNumber()
-          : (await getCurrentSlot(parent)) * slotIncrease
-        const newSlot = meta.registry.createType<Slot>('Slot', relayCurrentSlot + slotIncrease)
+          : (await getCurrentSlot(parent)) * relaySlotIncrease
+        const newSlot = meta.registry.createType<Slot>('Slot', relayCurrentSlot + relaySlotIncrease)
         newEntries.push([key, u8aToHex(newSlot.toU8a())])
       } else {
         newEntries.push([key, decoded[key]])
@@ -277,7 +277,7 @@ export class SetValidationData implements InherentProvider {
       validationData: {
         ...extrinsic.validationData,
         relayParentStorageRoot: trieRootHash,
-        relayParentNumber: extrinsic.validationData.relayParentNumber + slotIncrease,
+        relayParentNumber: extrinsic.validationData.relayParentNumber + relaySlotIncrease,
       },
       relayChainState: {
         trieNodes: nodes,

--- a/packages/core/src/blockchain/inherent/timestamp.ts
+++ b/packages/core/src/blockchain/inherent/timestamp.ts
@@ -9,7 +9,7 @@ export class SetTimestamp implements InherentProvider {
     const parent = await newBlock.parentBlock
     if (!parent) throw new Error('parent block not found')
     const meta = await parent.meta
-    const slotDuration = await getSlotDuration(parent)
+    const slotDuration = await getSlotDuration(newBlock)
     const currentTimestamp = await getCurrentTimestamp(parent)
     return [new GenericExtrinsic(meta.registry, meta.tx.timestamp.set(currentTimestamp + BigInt(slotDuration))).toHex()]
   }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -127,11 +127,8 @@ export const getCurrentTimestamp = async (head: Block) => {
 
 export const getSlotDuration = async (head: Block) => {
   const meta = await head.meta
-  return meta.consts.babe
-    ? (meta.consts.babe.expectedBlockTime as any as BN).toNumber()
-    : meta.query.aura
-      ? getAuraSlotDuration(await head.wasm)
-      : meta.consts.asyncBacking
-        ? (meta.consts.asyncBacking.expectedBlockTime as any as BN).toNumber()
-        : 12_000
+  let slotDuration: number
+  slotDuration ??= (meta.consts.babe?.expectedBlockTime as any as BN)?.toNumber()
+  slotDuration ??= (meta.consts.asyncBacking?.expectedBlockTime as any as BN)?.toNumber()
+  return slotDuration || getAuraSlotDuration(await head.wasm).catch(() => 12_000)
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,6 +1,5 @@
-import { BN, compactStripLength, hexToU8a, u8aToHex } from '@polkadot/util'
+import { BN, compactStripLength, u8aToHex } from '@polkadot/util'
 import { HexString } from '@polkadot/util/types'
-import { Slot } from '@polkadot/types/interfaces'
 import { StorageKey } from '@polkadot/types'
 import { getAuraSlotDuration } from '../wasm-executor/index.js'
 import { hexAddPrefix, hexStripPrefix } from '@polkadot/util/hex'
@@ -114,22 +113,7 @@ export const stripChildPrefix = (key: HexString) => {
   return storageKey
 }
 
-// use raw key here because some chain did not expose those storage to metadata
-const POTENTIAL_SLOT_KEYS = [
-  '0x1cb6f36e027abb2091cfb5110ab5087f06155b3cd9a8c9e5e9a23fd5dc13a5ed', // babe.currentSlot
-  '0x57f8dc2f5ab09467896f47300f04243806155b3cd9a8c9e5e9a23fd5dc13a5ed', // aura.currentSlot
-  '0x8985dff79e6002d0deba9ddac46f32a5a70806914c906d747e668a21f9021729', // asynchronousBacking.slotInfo
-  '0xab2a8d5eca218f218c6fda6b1d22bb926bc171ab77f6a731a6e80c34ee1eda19', // authorInherent.highestSlotSeen
-]
-
 export const getCurrentSlot = async (head: Block) => {
-  const meta = await head.meta
-  for (const key of POTENTIAL_SLOT_KEYS) {
-    const slotRaw = await head.get(key)
-    if (slotRaw) {
-      return meta.registry.createType<Slot>('Slot', hexToU8a(slotRaw)).toNumber()
-    }
-  }
   const timestamp = await getCurrentTimestamp(head)
   const slotDuration = await getSlotDuration(head)
   return Math.floor(Number(timestamp / BigInt(slotDuration)))

--- a/packages/e2e/src/connect-horizontal.test.ts
+++ b/packages/e2e/src/connect-horizontal.test.ts
@@ -14,7 +14,7 @@ describe('connectHorizontal', () => {
       },
     })
     const zeitgeist = await setupContext({
-      endpoint: 'wss://main.rpc.zeitgeist.pm/ws',
+      endpoint: ['wss://main.rpc.zeitgeist.pm/ws', 'wss://zeitgeist.api.onfinality.io/public-ws'],
       blockNumber: 5084336,
       db: !process.env.RUN_TESTS_WITHOUT_DB ? 'e2e-tests-db.sqlite' : undefined,
     })


### PR DESCRIPTION
Slot injected into aura digests needs to be calculated rather than incrementing by one
This will make it possible to transition from 12s block to 6s block time