### PR TITLE
Add one more condition to check whether the parachain is async backing chain

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -149,5 +149,8 @@ export const getSlotDuration = async (head: Block) => {
       ? getAuraSlotDuration(await head.wasm)
       : meta.consts.asyncBacking
         ? (meta.consts.asyncBacking.expectedBlockTime as any as BN).toNumber()
-        : 12_000
+          : meta.consts.timestamp?.minimumPeriod && (meta.consts.timestamp.minimumPeriod as any as BN).toNumber() === 0
+            // Async backing setting
+            ? 6_000
+            : 12_000
 }


### PR DESCRIPTION
Support the slot duration if the aura didn't expose

Based on the Parity team's async implementation doc, the meta.consts.timestamp.minimumPeriod == 0 should represent async backing.

https://wiki.polkadot.network/docs/maintain-guides-async-backing