### PR TITLE
Add Coretime Polkadot config

### DIFF
--- a/configs/polkadot-coretime.yml
+++ b/configs/polkadot-coretime.yml
@@ -1,0 +1,16 @@
+endpoint: wss://polkadot-coretime-rpc.polkadot.io
+mock-signature-host: true
+block: ${env.POLKADOT_CORETIME_BLOCK_NUMBER}
+db: ./db.sqlite
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: 1000000000000000
+
+


### PR DESCRIPTION
Another trivial one to add the config for Polkadot Coretime.

RPC is live even though the chain is not yet making blocks