### PR TITLE
feat: add transaction_v1 group of functions

### DIFF
--- a/packages/core/src/rpc/rpc-spec/index.ts
+++ b/packages/core/src/rpc/rpc-spec/index.ts
@@ -1,9 +1,11 @@
 import * as ChainHeadV1RPC from './chainHead_v1.js'
+import * as TransactionV1RPC from './transaction_v1.js'
 
-export { ChainHeadV1RPC }
+export { ChainHeadV1RPC, TransactionV1RPC }
 
 const handlers = {
   ...ChainHeadV1RPC,
+  ...TransactionV1RPC,
 }
 
 export default handlers

--- a/packages/core/src/rpc/rpc-spec/transaction_v1.ts
+++ b/packages/core/src/rpc/rpc-spec/transaction_v1.ts
@@ -1,0 +1,33 @@
+import { Handler } from '../shared.js'
+import { HexString } from '@polkadot/util/types'
+import { defaultLogger } from '@acala-network/chopsticks-core'
+
+const logger = defaultLogger.child({ name: 'rpc-transaction_v1' })
+const randomId = () => Math.random().toString(36).substring(2)
+
+/**
+ * Submit the extrinsic to the transaction pool
+ *
+ * @param context
+ * @param params - [`extrinsic`]
+ *
+ * @return operation id
+ */
+export const transaction_v1_broadcast: Handler<[HexString], string | null> = async (context, [extrinsic]) => {
+  await context.chain.submitExtrinsic(extrinsic).catch((err) => {
+    // As per the spec, the invalid transaction errors should be ignored.
+    logger.warn('Submit extrinsic failed', err)
+  })
+
+  return randomId()
+}
+
+/**
+ * Stop broadcasting the transaction to other nodes.
+ *
+ */
+export const transaction_v1_stop: Handler<[string], null> = async (_context, [_operationId]) => {
+  // Chopsticks doesn't have any process to broadcast the transaction through P2P
+  // so stopping doesn't have any effect.
+  return null
+}

--- a/packages/core/src/rpc/rpc-spec/transaction_v1.ts
+++ b/packages/core/src/rpc/rpc-spec/transaction_v1.ts
@@ -1,6 +1,6 @@
 import { Handler } from '../shared.js'
 import { HexString } from '@polkadot/util/types'
-import { defaultLogger } from '@acala-network/chopsticks-core'
+import { defaultLogger } from '../../logger.js'
 
 const logger = defaultLogger.child({ name: 'rpc-transaction_v1' })
 const randomId = () => Math.random().toString(36).substring(2)

--- a/packages/e2e/src/helper.ts
+++ b/packages/e2e/src/helper.ts
@@ -201,6 +201,7 @@ export const setupPolkadotApi = async (option: SetupOption) => {
     chain: null as unknown as Blockchain,
     substrateClient: null as unknown as SubstrateClient,
     observableClient: null as unknown as ObservableClient,
+    ws: null as unknown as WsProvider,
   }
 
   beforeAll(async () => {
@@ -212,7 +213,7 @@ export const setupPolkadotApi = async (option: SetupOption) => {
 
   beforeEach(async () => {
     const res = await setup()
-    ws = res.ws
+    ws = result.ws = res.ws
     chain = result.chain = res.chain
     result.substrateClient = res.substrateClient
     result.observableClient = res.observableClient

--- a/packages/e2e/src/rpc-spec.test.ts
+++ b/packages/e2e/src/rpc-spec.test.ts
@@ -1,6 +1,8 @@
 import { ApiPromise } from '@polkadot/api'
+import { RuntimeContext } from '@polkadot-api/observable-client'
 import { describe, expect, it } from 'vitest'
 import { dev, env, observe, setupPolkadotApi, testingPairs } from './helper.js'
+import { firstValueFrom } from 'rxjs'
 
 const testApi = await setupPolkadotApi(env.acalaV15)
 
@@ -12,15 +14,16 @@ describe('transaction_v1', async () => {
 
     const api = await prepareChainForTx()
 
-    const tx = await api.tx.balances.transferKeepAlive(bob.address, 100n).signAsync(alice)
+    const TRANSFERRED_VALUE = 100n
+    const tx = await api.tx.balances.transferKeepAlive(bob.address, TRANSFERRED_VALUE).signAsync(alice)
     const { nextValue, subscription } = observe(chainHead.trackTx$(tx.toHex()))
     const resultPromise = nextValue()
     const broadcast = testApi.observableClient.broadcastTx$(tx.toHex()).subscribe()
 
     // We don't have a confirmation of when the transaction has been broadcasted through the network
     // it just continues to get broadcasted through the nodes until we unsubscribe from it.
-    // In this case, where there's only one node, waiting for 300ms should be enough.
-    await new Promise((resolve) => setTimeout(resolve, 300))
+    // In this case, where there's only one node, waiting for 500ms should be enough.
+    await new Promise((resolve) => setTimeout(resolve, 500))
     const hash = await dev.newBlock()
 
     expect(await resultPromise).toMatchObject({
@@ -30,13 +33,24 @@ describe('transaction_v1', async () => {
       },
     })
 
+    const keyEncoder = (addr: string) => (ctx: RuntimeContext) =>
+      ctx.dynamicBuilder.buildStorage('System', 'Account').enc(addr)
+    const resultDecoder = (data: string | null, ctx: RuntimeContext) =>
+      data ? ctx.dynamicBuilder.buildStorage('System', 'Account').dec(data) : null
+    expect(
+      await firstValueFrom(chainHead.storage$(null, 'value', keyEncoder(bob.address), null, resultDecoder)),
+    ).toMatchObject({
+      data: {
+        free: INITIAL_ACCOUNT_VALUE + TRANSFERRED_VALUE,
+      },
+    })
+
     broadcast.unsubscribe()
     subscription.unsubscribe()
     chainHead.unfollow()
   })
 })
 
-const UPGRADED = 0x80000000_00000000_00000000_00000000n
 const INITIAL_ACCOUNT_VALUE = 100_000_000_000_000n
 async function prepareChainForTx() {
   const api = await ApiPromise.create({
@@ -50,10 +64,17 @@ async function prepareChainForTx() {
         [
           [alice.address],
           {
-            data: { free: INITIAL_ACCOUNT_VALUE, flags: UPGRADED },
+            providers: 1,
+            data: { free: INITIAL_ACCOUNT_VALUE },
           },
         ],
-        [[bob.address], { data: { free: INITIAL_ACCOUNT_VALUE, flags: UPGRADED } }],
+        [
+          [bob.address],
+          {
+            providers: 1,
+            data: { free: INITIAL_ACCOUNT_VALUE },
+          },
+        ],
       ],
     },
     Sudo: {

--- a/packages/e2e/src/rpc-spec.test.ts
+++ b/packages/e2e/src/rpc-spec.test.ts
@@ -19,8 +19,8 @@ describe('transaction_v1', async () => {
 
     // We don't have a confirmation of when the transaction has been broadcasted through the network
     // it just continues to get broadcasted through the nodes until we unsubscribe from it.
-    // In this case, where there's only one node, a couple of blocks should be enough.
-    await dev.newBlock()
+    // In this case, where there's only one node, waiting for 300ms should be enough.
+    await new Promise((resolve) => setTimeout(resolve, 300))
     const hash = await dev.newBlock()
 
     expect(await resultPromise).toMatchObject({

--- a/packages/e2e/src/rpc-spec.test.ts
+++ b/packages/e2e/src/rpc-spec.test.ts
@@ -1,0 +1,65 @@
+import { ApiPromise } from '@polkadot/api'
+import { describe, expect, it } from 'vitest'
+import { dev, env, observe, setupPolkadotApi, testingPairs } from './helper.js'
+
+const testApi = await setupPolkadotApi(env.acalaV15)
+
+const { alice, bob } = testingPairs()
+
+describe('transaction_v1', async () => {
+  it('sends and executes transactions', async () => {
+    const chainHead = testApi.observableClient.chainHead$()
+
+    const api = await prepareChainForTx()
+
+    const tx = await api.tx.balances.transferKeepAlive(bob.address, 100n).signAsync(alice)
+    const { nextValue, subscription } = observe(chainHead.trackTx$(tx.toHex()))
+    const resultPromise = nextValue()
+    const broadcast = testApi.observableClient.broadcastTx$(tx.toHex()).subscribe()
+
+    // We don't have a confirmation of when the transaction has been broadcasted through the network
+    // it just continues to get broadcasted through the nodes until we unsubscribe from it.
+    // In this case, where there's only one node, a couple of blocks should be enough.
+    await dev.newBlock()
+    const hash = await dev.newBlock()
+
+    expect(await resultPromise).toMatchObject({
+      hash,
+      found: {
+        type: true,
+      },
+    })
+
+    broadcast.unsubscribe()
+    subscription.unsubscribe()
+    chainHead.unfollow()
+  })
+})
+
+const UPGRADED = 0x80000000_00000000_00000000_00000000n
+const INITIAL_ACCOUNT_VALUE = 100_000_000_000_000n
+async function prepareChainForTx() {
+  const api = await ApiPromise.create({
+    provider: testApi.ws,
+    noInitWarn: true,
+  })
+  await api.isReady
+  await dev.setStorage({
+    System: {
+      Account: [
+        [
+          [alice.address],
+          {
+            data: { free: INITIAL_ACCOUNT_VALUE, flags: UPGRADED },
+          },
+        ],
+        [[bob.address], { data: { free: INITIAL_ACCOUNT_VALUE, flags: UPGRADED } }],
+      ],
+    },
+    Sudo: {
+      Key: alice.address,
+    },
+  })
+
+  return api
+}


### PR DESCRIPTION
This PR adds the `transaction_v1` group of functions of the JSON RPC interface spec into the RPC server.

It's fairly simple, since it's only two functions: one starting a broadcast, and the other to stop it.

We'll be missing only one last group to make it fully compatible with papi, the `chainSpec` one. Looks fairly simple, will work on it next and raise as a separate PR.
