### PR TITLE
feat: add chainSpec_v1 group of functions

### DIFF
--- a/packages/core/src/rpc/rpc-spec/chainSpec_v1.ts
+++ b/packages/core/src/rpc/rpc-spec/chainSpec_v1.ts
@@ -1,0 +1,14 @@
+import { ChainProperties } from '../../index.js'
+import { Handler } from '../shared.js'
+
+export const chainSpec_v1_chainName: Handler<[], string> = async (context) => {
+  return context.chain.api.getSystemChain()
+}
+
+export const chainSpec_v1_genesisHash: Handler<[], string> = async (context) => {
+  return (await context.chain.api.getBlockHash(0)) ?? ''
+}
+
+export const chainSpec_v1_properties: Handler<[], ChainProperties> = async (context) => {
+  return context.chain.api.getSystemProperties()
+}

--- a/packages/core/src/rpc/rpc-spec/chainSpec_v1.ts
+++ b/packages/core/src/rpc/rpc-spec/chainSpec_v1.ts
@@ -1,12 +1,17 @@
 import { ChainProperties } from '../../index.js'
-import { Handler } from '../shared.js'
+import { Handler, ResponseError } from '../shared.js'
+import { HexString } from '@polkadot/util/types'
 
 export const chainSpec_v1_chainName: Handler<[], string> = async (context) => {
   return context.chain.api.getSystemChain()
 }
 
-export const chainSpec_v1_genesisHash: Handler<[], string> = async (context) => {
-  return (await context.chain.api.getBlockHash(0)) ?? ''
+export const chainSpec_v1_genesisHash: Handler<[], HexString> = async (context) => {
+  const genesisHash = await context.chain.api.getBlockHash(0)
+  if (genesisHash === null) {
+    throw new ResponseError(1, 'Unexpected null genesis hash')
+  }
+  return genesisHash
 }
 
 export const chainSpec_v1_properties: Handler<[], ChainProperties> = async (context) => {

--- a/packages/core/src/rpc/rpc-spec/index.ts
+++ b/packages/core/src/rpc/rpc-spec/index.ts
@@ -1,11 +1,13 @@
 import * as ChainHeadV1RPC from './chainHead_v1.js'
+import * as ChainSpecV1RPC from './chainSpec_v1.js'
 import * as TransactionV1RPC from './transaction_v1.js'
 
-export { ChainHeadV1RPC, TransactionV1RPC }
+export { ChainHeadV1RPC, TransactionV1RPC, ChainSpecV1RPC }
 
 const handlers = {
   ...ChainHeadV1RPC,
   ...TransactionV1RPC,
+  ...ChainSpecV1RPC,
 }
 
 export default handlers

--- a/packages/e2e/src/__snapshots__/rpc-spec.test.ts.snap
+++ b/packages/e2e/src/__snapshots__/rpc-spec.test.ts.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`chainSpec_v1 > retrieves the chainSpec data 1`] = `
+{
+  "genesisHash": "0xfc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
+  "name": "Acala",
+  "properties": {
+    "ss58Format": 10,
+    "tokenDecimals": [
+      12,
+      12,
+      10,
+      10,
+    ],
+    "tokenSymbol": [
+      "ACA",
+      "AUSD",
+      "DOT",
+      "LDOT",
+    ],
+  },
+}
+`;

--- a/packages/e2e/src/rpc-spec.test.ts
+++ b/packages/e2e/src/rpc-spec.test.ts
@@ -47,6 +47,12 @@ describe('transaction_v1', async () => {
   })
 })
 
+describe('chainSpec_v1', () => {
+  it('retrieves the chainSpec data', async () => {
+    expect(await testApi.substrateClient.getChainSpecData()).toMatchSnapshot()
+  })
+})
+
 const INITIAL_ACCOUNT_VALUE = 100_000_000_000_000n
 async function prepareChainForTx() {
   const api = await ApiPromise.create({


### PR DESCRIPTION
Last missing group of functions to provide support with papi, so this closes #801 

I may need help with the `genesisHash` function - I thought this would be available on the chain object directly, but it's not.

I called `getBlockHash(0)`, which seems to get the job done, it seems to work when starting from genesis and from a wsUrl, but the types say it might return null. I couldn't find any case where this happens, but I'm also not sure what to do in this case.... any ideas?