### PR TITLE
Rework author noting inherent mock and stagelight config

### DIFF
--- a/configs/stagelight.yml
+++ b/configs/stagelight.yml
@@ -1,0 +1,14 @@
+endpoint: wss://stagelight.tanssi-dev.network
+block: ${env.FLASHBOX_BLOCK_NUMBER}
+mock-signature-host: true
+db: ./tmp/db_mba.sqlite
+
+import-storage:
+    System:
+        Account:
+            - - - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+              - providers: 1
+                data:
+                    free: "100000000000000000000000"
+    Sudo:
+        Key: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"

--- a/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
+++ b/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
@@ -11,14 +11,16 @@ export class SetNimbusAuthorInherent implements InherentProvider {
     if (!parent) throw new Error('parent block not found')
 
     const meta = await parent.meta
-    
+
     // mock author inherent data and authorities noting data
     const layer = newBlock.pushStorageLayer()
 
-    layer.set(
-      compactHex(meta.query.authorNoting.didSetContainerAuthorData()),
-      meta.registry.createType('bool', true).toHex(),
-    )
+    if (meta.query.authorNoting) {
+      layer.set(
+        compactHex(meta.query.authorNoting.didSetContainerAuthorData()),
+        meta.registry.createType('bool', true).toHex(),
+      )
+    }
 
     if (!meta.tx.authorInherent?.kickOffAuthorshipValidation) {
       return []
@@ -70,7 +72,6 @@ export class SetNimbusAuthorInherent implements InherentProvider {
             .toHex(),
         )
       }
-  
     }
     return [new GenericExtrinsic(meta.registry, meta.tx.authorInherent.kickOffAuthorshipValidation()).toHex()]
   }

--- a/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
+++ b/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
@@ -12,19 +12,20 @@ export class SetNimbusAuthorInherent implements InherentProvider {
 
     const meta = await parent.meta
 
-    // mock author inherent data and authorities noting data
-    const layer = newBlock.pushStorageLayer()
-
-    if (meta.query.authorNoting) {
-      layer.set(
-        compactHex(meta.query.authorNoting.didSetContainerAuthorData()),
-        meta.registry.createType('bool', true).toHex(),
-      )
-    }
-
     if (!meta.tx.authorInherent?.kickOffAuthorshipValidation) {
+      if (meta.query.authorNoting) {
+        newBlock
+          .pushStorageLayer()
+          .set(
+            compactHex(meta.query.authorNoting.didSetContainerAuthorData()),
+            meta.registry.createType('bool', true).toHex(),
+          )
+      }
       return []
     }
+
+    // mock author inherent data and authorities noting data
+    const layer = newBlock.pushStorageLayer()
 
     const accountType = meta.registry.hasType('NimbusPrimitivesNimbusCryptoPublic')
       ? 'NimbusPrimitivesNimbusCryptoPublic'
@@ -72,6 +73,10 @@ export class SetNimbusAuthorInherent implements InherentProvider {
             .toHex(),
         )
       }
+      layer.set(
+        compactHex(meta.query.authorNoting.didSetContainerAuthorData()),
+        meta.registry.createType('bool', true).toHex(),
+      )
     }
     return [new GenericExtrinsic(meta.registry, meta.tx.authorInherent.kickOffAuthorshipValidation()).toHex()]
   }

--- a/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
+++ b/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
@@ -11,12 +11,19 @@ export class SetNimbusAuthorInherent implements InherentProvider {
     if (!parent) throw new Error('parent block not found')
 
     const meta = await parent.meta
-    if (!meta.tx.authorInherent?.kickOffAuthorshipValidation) {
-      return []
-    }
-
+    
     // mock author inherent data and authorities noting data
     const layer = newBlock.pushStorageLayer()
+
+    layer.set(
+      compactHex(meta.query.authorNoting.didSetContainerAuthorData()),
+      meta.registry.createType('bool', true).toHex(),
+    )
+
+    if (!meta.tx.authorInherent?.kickOffAuthorshipValidation) {
+      console.log("not found")
+      return []
+    }
 
     const accountType = meta.registry.hasType('NimbusPrimitivesNimbusCryptoPublic')
       ? 'NimbusPrimitivesNimbusCryptoPublic'
@@ -64,11 +71,7 @@ export class SetNimbusAuthorInherent implements InherentProvider {
             .toHex(),
         )
       }
-
-      layer.set(
-        compactHex(meta.query.authorNoting.didSetContainerAuthorData()),
-        meta.registry.createType('bool', true).toHex(),
-      )
+  
     }
     return [new GenericExtrinsic(meta.registry, meta.tx.authorInherent.kickOffAuthorshipValidation()).toHex()]
   }

--- a/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
+++ b/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
@@ -7,7 +7,7 @@ import { compactHex } from '../../../utils/index.js'
 // Support for Nimbus Author Inherent
 export class SetNimbusAuthorInherent implements InherentProvider {
   async createInherents(newBlock: Block, _params: BuildBlockParams): Promise<HexString[]> {
-    const parent = await newBlock.parentBlock
+    const parent = await newB lock.parentBlock
     if (!parent) throw new Error('parent block not found')
 
     const meta = await parent.meta
@@ -21,7 +21,6 @@ export class SetNimbusAuthorInherent implements InherentProvider {
     )
 
     if (!meta.tx.authorInherent?.kickOffAuthorshipValidation) {
-      console.log("not found")
       return []
     }
 

--- a/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
+++ b/packages/core/src/blockchain/inherent/parachain/nimbus-author-inherent.ts
@@ -7,7 +7,7 @@ import { compactHex } from '../../../utils/index.js'
 // Support for Nimbus Author Inherent
 export class SetNimbusAuthorInherent implements InherentProvider {
   async createInherents(newBlock: Block, _params: BuildBlockParams): Promise<HexString[]> {
-    const parent = await newB lock.parentBlock
+    const parent = await newBlock.parentBlock
     if (!parent) throw new Error('parent block not found')
 
     const meta = await parent.meta


### PR DESCRIPTION
This PR moves the mock of `author noting` before the `kick_off_authorship` inherent checks. We have a new chain in which we only run the author noting inherent but not the `kick_off_authorship` inherent, which would fail before this PR. This should not affect any of the other chains as we are only mocking the storage that verifies on_finalize that the inherent has run.

Additionally, I added a new config for the new chain, which we are calling stagelight. this is for now just the stagenet version of a testnet that will be launched in a couple of weeks, once we launch it I will make a PR putting the testnet config file