### PR TITLE
Add `archive_unstable_hashByHeight` as alias to `chain_getBlockHash`

### DIFF
--- a/packages/core/src/rpc/substrate/chain.ts
+++ b/packages/core/src/rpc/substrate/chain.ts
@@ -114,6 +114,7 @@ export const chain_unsubscribeNewHead: Handler<[string], void> = async (_context
   unsubscribe(subid)
 }
 
+export const archive_unstable_hashByHeight = chain_getBlockHash
 export const chain_getHead = chain_getBlockHash
 export const chain_subscribeNewHeads = chain_subscribeNewHead
 export const chain_unsubscribeNewHeads = chain_unsubscribeNewHead

--- a/packages/e2e/src/chain.test.ts
+++ b/packages/e2e/src/chain.test.ts
@@ -29,6 +29,8 @@ describe('chain rpc', () => {
     expect(await api.rpc('chain_getBlockHash', '0x03e8')).toEqual(hash1000)
     expect(await api.rpc('chain_getBlockHash', ['0x03e8'])).toEqual(expect.arrayContaining([hash1000]))
     expect(await api.rpc('chain_getBlockHash', ['0x03e8', null])).toEqual(expect.arrayContaining([hash1000, hashHead]))
+    // alias works
+    expect(await api.rpc('archive_unstable_hashByHeight', [1000])).toEqual(expect.arrayContaining([hash1000]))
 
     await check(api.rpc.chain.getHeader()).toMatchSnapshot()
     await check(api.rpc.chain.getHeader(hashHead)).toMatchSnapshot()


### PR DESCRIPTION
closes #852