### PR TITLE
Adds a simple project introduction to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 Create parallel reality of your Substrate network.
 
+## Introduction
+
+Chopsticks provides a developer-friendly method of locally forking existing Substrate based chains. It allows for the replaying of blocks to easily examine how extrinsics effect state, the forking of multiple blocks for XCM testing, and more. This allows developers to test and experiment with their own custom blockchain configurations in a local development environment, without the need to deploy a live network. Chopsticks aims to simplify the process of building blockchain applications on Substrate and make it accessible to a wider range of developers.
+
 ## Quick Start
 
 Fork Acala mainnet: `npx @acala-network/chopsticks@latest --endpoint=wss://acala-rpc-2.aca-api.network/ws`


### PR DESCRIPTION
This PR takes the introduction paragraph from the Moonbeam docs and places it at the head of this repo's README.

---

I found this repo from a link in a group chat, but struggled to figure out what this repo was actually for. The text "Create parallel reality of your Substrate network" didn't clear anything up. 

After a bit of searching I found the Moonbeam docs with a page detailing how to use Chopsticks with Moonbeam: https://docs.moonbeam.network/builders/substrate/dev-env/chopsticks/. I figured that intro would work well here too.

**Repo maintainers: Feel free to ignore this PR if you think it isn't necessary. You won't hurt my feelings.**