### PR TITLE
Fix loopback address display for IPv6

### DIFF
--- a/packages/chopsticks/src/server.ts
+++ b/packages/chopsticks/src/server.ts
@@ -289,6 +289,11 @@ export const createServer = async (handler: Handler, port: number, host?: string
     })
   })
 
+  // Localhost in IPv6 is ::1, and not ::, which the code below will display.
+  if (addressInfo.family === 'IPv6' && addressInfo.address === '::') {
+    addressInfo.address = '::1'
+  }
+
   return {
     addr: `${addressInfo.family === 'IPv6' ? `[${addressInfo.address}]` : addressInfo.address}:${addressInfo.port}`,
     port: addressInfo.port,


### PR DESCRIPTION
In IPv6, the loopback address is `::1`, short for `0000:0000:0000:0000:0000:0000:0000:0001`.
Before this commit, it was displayed as `::`, which is short for `0000:0000:0000:0000:0000:0000:0000:0000` - not the same addresses.

See [RFC 4219 for IPv6](https://www.rfc-editor.org/rfc/rfc4291#section-2.2).