### PR TITLE
default to finalzied head

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -106,6 +106,10 @@ export class Api {
     return this.send<Header | null>('chain_getHeader', hash ? [hash] : [], !!hash)
   }
 
+  async getFinalizedHead() {
+    return this.send<string>('chain_getFinalizedHead', [])
+  }
+
   async getBlock(hash?: string) {
     return this.send<SignedBlock | null>('chain_getBlock', hash ? [hash] : [], !!hash)
   }

--- a/packages/core/src/genesis-provider.ts
+++ b/packages/core/src/genesis-provider.ts
@@ -158,6 +158,7 @@ export class GenesisProvider implements ProviderInterface {
       case 'chain_getBlock':
         return this.getBlock()
       case 'chain_getBlockHash':
+      case 'chain_getFinalizedHead':
         return this.blockHash
       case 'state_getKeysPaged':
       case 'state_getKeysPagedAt': {

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -50,7 +50,7 @@ export const processOptions = async (options: SetupOptions) => {
 
   let blockHash: string
   if (options.block == null) {
-    blockHash = await api.getBlockHash().then((hash) => {
+    blockHash = await api.getFinalizedHead().then((hash) => {
       if (!hash) {
         // should not happen, but just in case
         throw new Error('Cannot find block hash')

--- a/packages/e2e/src/connect-horizontal.test.ts
+++ b/packages/e2e/src/connect-horizontal.test.ts
@@ -14,7 +14,7 @@ describe('connectHorizontal', () => {
       },
     })
     const zeitgeist = await setupContext({
-      endpoint: ['wss://main.rpc.zeitgeist.pm/ws', 'wss://zeitgeist.api.onfinality.io/public-ws'],
+      endpoint: ['wss://zeitgeist.api.onfinality.io/public-ws'],
       blockNumber: 5084336,
       db: !process.env.RUN_TESTS_WITHOUT_DB ? 'e2e-tests-db.sqlite' : undefined,
     })


### PR DESCRIPTION
closes #841

when no block specified, instead of using best head, use finalized head instead. this ensures we won't be building new blocks on a fork, which will be inaccessible after it is purged