### PR TITLE
Add: Energy Web X parachain mainnet and testnet config file

### DIFF
--- a/configs/energywebx.yml
+++ b/configs/energywebx.yml
@@ -1,0 +1,22 @@
+# Energy Web X on Pokadot Network (Energy Web X Mainnet)
+endpoint:
+  - wss://public-rpc.mainnet.energywebx.com
+  - wss://wnp-rpc.mainnet.energywebx.com
+  - wss://wns-rpc.mainnet.energywebx.com
+mock-signature-host: true
+block: ${env.ENERGYWBEX_BLOCK_NUMBER}
+db: ./ewx.db.sqlite
+# wasm-override: ew_parachain_runtime.compact.compressed.wasm
+
+runtime-log-level: 5
+import-storage:
+  Sudo:
+    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - providers: 1
+          data:
+            free: '50000000000000000000'

--- a/configs/pex.yml
+++ b/configs/pex.yml
@@ -1,0 +1,21 @@
+# Energy Web X on Paseo Network (Energy Web X Testnet)
+endpoint:
+  - wss://public-rpc.testnet.energywebx.com
+  - wss://wnp-rpc.testnet.energywebx.com
+mock-signature-host: true
+block: ${env.PEX_BLOCK_NUMBER}
+db: ./pex.db.sqlite
+# wasm-override: ew_parachain_runtime.compact.compressed.wasm
+
+runtime-log-level: 5
+import-storage:
+  Sudo:
+    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - providers: 1
+          data:
+            free: '50000000000000000000'


### PR DESCRIPTION
Add specs for Energy Web X mainnet and Energy Web X on the Paseo testnet for integration into Chopstick.