### PR TITLE
feat: add paseo config

### DIFF
--- a/configs/paseo.yml
+++ b/configs/paseo.yml
@@ -1,0 +1,16 @@
+endpoint: wss://paseo-rpc.dwellir.com
+mock-signature-host: true
+block: ${env.PASEO_BLOCK_NUMBER}
+db: ./db.sqlite
+
+import-storage:
+  Sudo:
+    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '10000000000000000000'


### PR DESCRIPTION
This adds a paseo.yml file so that a paseo chopsticks instance can be spawned with `chopsticks -c paseo`.

I'm using Dwellir RPC, I'm not sure if that's acceptable, and setting ALICE as sudo key (similar to other config files for test networks)