### PR TITLE
Add RPC Timeout Option to Setup and Context Configuration

### DIFF
--- a/packages/chopsticks/src/context.ts
+++ b/packages/chopsticks/src/context.ts
@@ -58,6 +58,7 @@ export const setupContext = async (argv: Config, overrideParent = false) => {
     offchainWorker: argv['offchain-worker'],
     maxMemoryBlockCount: argv['max-memory-block-count'],
     processQueuedMessages: argv['process-queued-messages'],
+    rpcTimeout: argv['rpc-timeout'],
     hooks: {
       apiFetching,
     },

--- a/packages/chopsticks/src/schema/index.ts
+++ b/packages/chopsticks/src/schema/index.ts
@@ -84,6 +84,7 @@ export const configSchema = z.object({
         'Storage key prefixes config for fetching storage, useful for testing big migrations, see README for examples',
     })
     .optional(),
+  'rpc-timeout': z.number({ description: 'RPC timeout in milliseconds' }).optional(),
 })
 
 export type Config = z.infer<typeof configSchema>

--- a/packages/chopsticks/src/schema/options.test.ts
+++ b/packages/chopsticks/src/schema/options.test.ts
@@ -116,6 +116,12 @@ it('get yargs options from zod schema', () => {
         "description": "Resume from the specified block hash or block number in db. If true, it will resume from the latest block in db. Note this will override the block option",
         "type": "string",
       },
+      "rpc-timeout": {
+        "choices": undefined,
+        "demandOption": false,
+        "description": "RPC timeout in milliseconds",
+        "type": "number",
+      },
       "runtime-log-level": {
         "choices": undefined,
         "demandOption": false,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -25,6 +25,7 @@ export type SetupOptions = {
   offchainWorker?: boolean
   maxMemoryBlockCount?: number
   processQueuedMessages?: boolean
+  rpcTimeout?: number
   hooks?: {
     apiFetching?: () => void
   }
@@ -39,7 +40,7 @@ export const processOptions = async (options: SetupOptions) => {
   } else if (typeof options.endpoint === 'string' && /^(https|http):\/\//.test(options.endpoint || '')) {
     provider = new HttpProvider(options.endpoint)
   } else {
-    provider = new WsProvider(options.endpoint, 3_000)
+    provider = new WsProvider(options.endpoint, 3_000, undefined, options.rpcTimeout)
   }
   const api = new Api(provider)
 

--- a/packages/e2e/src/helper.ts
+++ b/packages/e2e/src/helper.ts
@@ -30,6 +30,7 @@ export type SetupOption = {
   registeredTypes?: RegisteredTypes
   runtimeLogLevel?: number
   processQueuedMessages?: boolean
+  rpcTimeout?: number
 }
 
 export const env = {
@@ -58,6 +59,7 @@ export const setupAll = async ({
   registeredTypes = {},
   runtimeLogLevel,
   processQueuedMessages,
+  rpcTimeout,
 }: SetupOption) => {
   let provider: ProviderInterface
   if (genesis) {
@@ -65,7 +67,7 @@ export const setupAll = async ({
   } else if (typeof endpoint === 'string' && /^(https|http):\/\//.test(endpoint || '')) {
     provider = new HttpProvider(endpoint)
   } else {
-    provider = new WsProvider(endpoint, 3_000)
+    provider = new WsProvider(endpoint, 3_000, undefined, rpcTimeout)
   }
   const api = new Api(provider)
 


### PR DESCRIPTION
Closes #906
Closes #896

**Summary of Changes**:
- Added an RPC timeout option to the setup and context configuration.
- Updated the `setupContext` function to include the RPC timeout option.
- Modified the `WsProvider` constructor to accept the RPC timeout option.

**Highlights of Changed Code**:
- The `setupContext` function now includes the `rpcTimeout` option in its configuration.
- The `WsProvider` constructor has been updated to accept the `rpcTimeout` option.

**Additional Information (if needed)**:
- The RPC timeout option allows for more control over the setup and context configuration.
- The changes are backwards compatible and do not introduce any breaking changes.