### PR TITLE
Update statemin* RPCs

### DIFF
--- a/configs/statemine.yml
+++ b/configs/statemine.yml
@@ -1,4 +1,4 @@
-endpoint: wss://statemine-rpc.dwellir.com
+endpoint: wss://asset-hub-kusama-rpc.dwellir.com
 mock-signature-host: true
 block: ${env.STATEMINE_BLOCK_NUMBER}
 db: ./db.sqlite

--- a/configs/statemint.yml
+++ b/configs/statemint.yml
@@ -1,4 +1,4 @@
-endpoint: wss://statemint-rpc.dwellir.com
+endpoint: wss://asset-hub-polkadot-rpc.dwellir.com
 mock-signature-host: true
 block: ${env.STATEMINT_BLOCK_NUMBER}
 db: ./db.sqlite


### PR DESCRIPTION
`npx @acala-network/chopsticks@latest -c statemint` is currently not working.  
Seems to be Dwellir renamed the RPC.