### PR TITLE
feat: add support for chainHead_v1_storage hash queries

### DIFF
--- a/packages/e2e/src/chainHead_v1.test.ts
+++ b/packages/e2e/src/chainHead_v1.test.ts
@@ -1,5 +1,6 @@
 import type { RuntimeContext } from '@polkadot-api/observable-client'
 import { describe, expect, it } from 'vitest'
+import { blake2AsHex } from '@polkadot/util-crypto'
 
 import { getPolkadotSigner } from 'polkadot-api/signer'
 import { firstValueFrom } from 'rxjs'
@@ -92,6 +93,39 @@ describe('chainHead_v1 rpc', () => {
       chainHead.storage$(null, 'descendantsValues', (ctx) =>
         ctx.dynamicBuilder.buildStorage('System', 'BlockHash').keys.enc(),
       ),
+    )
+
+    expect(receivedItems.length).toEqual(1201)
+
+    chainHead.unfollow()
+  })
+
+  it("calculates storage hashes as blake2 of the value", async () => {
+    const chainHead = testApi.observableClient.chainHead$()
+
+    const keyEncoder = (addr: string) => (ctx: RuntimeContext) =>
+      ctx.dynamicBuilder.buildStorage("System", "Account").keys.enc(addr)
+
+    // With an existing value it returns the SCALE-encoded value.
+    const account = await firstValueFrom(
+      chainHead.storage$(null, "value", keyEncoder("2636WSLQhSLPAb4rd7qPgCpSKEjAz6FAbHYPAex6phJLNBfH"))
+    )
+    expect(account).not.toBe(null)
+    const hash = await firstValueFrom(
+      chainHead.storage$(null, "hash", keyEncoder("2636WSLQhSLPAb4rd7qPgCpSKEjAz6FAbHYPAex6phJLNBfH"))
+    )
+    expect(hash).toEqual(blake2AsHex(account!))
+
+    chainHead.unfollow()
+  })
+
+  it("runs through multiple pages of storage hashes", async () => {
+    const chainHead = testApi.observableClient.chainHead$()
+
+    const receivedItems = await firstValueFrom(
+      chainHead.storage$(null, "descendantsHashes", (ctx) =>
+        ctx.dynamicBuilder.buildStorage("System", "BlockHash").keys.enc()
+      )
     )
 
     expect(receivedItems.length).toEqual(1201)


### PR DESCRIPTION
I think this is the last piece that was missing for `chainHead_v1` - Support for hash queries.

IIRC we postponed this because there was no direct way of getting the hashed values. What I used to solve it in this PR is to grab the value and hash it with blake2.

We recently added a feature that relies on this for papi, and with chopsticks it was always returning `null` and logging the "not implemented" warning.