### PR TITLE
ChopsticksProvider: Add wrapper for PAPI's JsonRpcProvider

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"@acala-network/chopsticks-executor": "workspace:*",
+		"@polkadot-api/json-rpc-provider": "^0.0.4",
 		"@polkadot/rpc-provider": "^15.7.1",
 		"@polkadot/types": "^15.7.1",
 		"@polkadot/types-codec": "^15.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,7 @@ __metadata:
   resolution: "@acala-network/chopsticks-core@workspace:packages/core"
   dependencies:
     "@acala-network/chopsticks-executor": "workspace:*"
+    "@polkadot-api/json-rpc-provider": "npm:^0.0.4"
     "@polkadot/rpc-provider": "npm:^15.7.1"
     "@polkadot/types": "npm:^15.7.1"
     "@polkadot/types-codec": "npm:^15.7.1"
@@ -1850,7 +1851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-api/json-rpc-provider@npm:0.0.4":
+"@polkadot-api/json-rpc-provider@npm:0.0.4, @polkadot-api/json-rpc-provider@npm:^0.0.4":
   version: 0.0.4
   resolution: "@polkadot-api/json-rpc-provider@npm:0.0.4"
   checksum: 10c0/5615394380bff2d8885592c8001055f1b006e3dd2f650b6a0e41ec836d61e903d78cc4ed06297827020523b0eecc9dff0af661fed7ae82523c97e294a2dc2e27


### PR DESCRIPTION
This Pull Request adds a wrapper for returning a `JsonRpcProvider` from `polkadot-api`.

A typical usage is this one:

```ts
import { createClient } from 'polkadot-api';
import { ChopsticksProvider, getPapiChopsticksProvider } from '@acalanetwork/chopsticks-core';

const client = createClient(
  getPapiChopsticksProvider(
    await ChopsticksProvider.fromEndpoint("wss://testnet.kreivo.kippu.rocks")
  )
);
```