### PR TITLE
feat: add getMany to storage queries

### DIFF
--- a/packages/core/src/blockchain/block.ts
+++ b/packages/core/src/blockchain/block.ts
@@ -166,7 +166,7 @@ export class Block {
    */
   async getMany(key: string[]): Promise<Array<HexString | undefined>> {
     const vals = await this.storage.getMany(key, true)
-    return vals.map(val => {
+    return vals.map((val) => {
       switch (val) {
         case StorageValueKind.Deleted:
           return undefined

--- a/packages/core/src/blockchain/block.ts
+++ b/packages/core/src/blockchain/block.ts
@@ -164,8 +164,8 @@ export class Block {
   /**
    * Get the block storage by key.
    */
-  async getMany(key: string[]): Promise<Array<HexString | undefined>> {
-    const vals = await this.storage.getMany(key, true)
+  async getMany(keys: string[]): Promise<Array<HexString | undefined>> {
+    const vals = await this.storage.getMany(keys, true)
     return vals.map((val) => {
       switch (val) {
         case StorageValueKind.Deleted:

--- a/packages/core/src/blockchain/block.ts
+++ b/packages/core/src/blockchain/block.ts
@@ -161,6 +161,21 @@ export class Block {
     }
   }
 
+  /**
+   * Get the block storage by key.
+   */
+  async getMany(key: string[]): Promise<Array<HexString | undefined>> {
+    const vals = await this.storage.getMany(key, true)
+    return vals.map(val => {
+      switch (val) {
+        case StorageValueKind.Deleted:
+          return undefined
+        default:
+          return val as HexString
+      }
+    })
+  }
+
   async read<T extends string>(type: T, query: StorageEntry, ...args: any[]) {
     const key = compactHex(query(...args))
     const value = await this.get(key)

--- a/packages/core/src/blockchain/get-keys-paged.test.ts
+++ b/packages/core/src/blockchain/get-keys-paged.test.ts
@@ -29,6 +29,7 @@ describe('getKeysPaged', () => {
   Api.prototype.getStorage = vi.fn(async (_key, _at) => {
     return '0x1' as any
   })
+  Api.prototype.getStorageBatch = vi.fn(async (_prefix, keys, _at) => keys.map(() => '0x1'))
   const mockApi = new Api(undefined!)
 
   const remoteLayer = new RemoteStorageLayer(mockApi, hash, undefined)

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -64,44 +64,44 @@ export class RemoteStorageLayer implements StorageLayerProvider {
   }
 
   async getMany(keys: string[], _cache: boolean): Promise<StorageValue[]> {
-    const result: StorageValue[] = [];
-    let pending = keys.map((key, idx) => ({ key, idx }));
+    const result: StorageValue[] = []
+    let pending = keys.map((key, idx) => ({ key, idx }))
 
     if (this.#db) {
       const results = await Promise.all(
-        pending.map(({ key }) => this.#db!.queryStorage(this.#at as HexString, key as HexString))
-      );
+        pending.map(({ key }) => this.#db!.queryStorage(this.#at as HexString, key as HexString)),
+      )
 
-      const oldPending = pending;
-      pending = [];
+      const oldPending = pending
+      pending = []
       results.forEach((res, idx) => {
         if (res) {
-          result[idx] = res.value ?? undefined;
+          result[idx] = res.value ?? undefined
         } else {
-          pending.push({ key: oldPending[idx].key, idx });
+          pending.push({ key: oldPending[idx].key, idx })
         }
-      });
+      })
     }
 
     if (pending.length) {
-      logger.trace({ at: this.#at, keys }, "RemoteStorageLayer getMany");
+      logger.trace({ at: this.#at, keys }, 'RemoteStorageLayer getMany')
       const data = await this.#api.getStorageBatch(
-        "0x",
+        '0x',
         pending.map(({ key }) => key as HexString),
-        this.#at
-      );
+        this.#at,
+      )
       data.forEach(([, res], idx) => {
-        result[pending[idx].idx] = res ?? undefined;
-      });
+        result[pending[idx].idx] = res ?? undefined
+      })
 
       if (this.#db?.saveStorageBatch) {
-        this.#db?.saveStorageBatch(data.map(([key, value]) => ({ key, value, blockHash: this.#at })));
+        this.#db?.saveStorageBatch(data.map(([key, value]) => ({ key, value, blockHash: this.#at })))
       } else if (this.#db) {
-        data.forEach(([key, value]) => this.#db?.saveStorage(this.#at, key, value));
+        data.forEach(([key, value]) => this.#db?.saveStorage(this.#at, key, value))
       }
     }
 
-    return result;
+    return result
   }
 
   async findNextKey(prefix: string, startKey: string, _knownBest?: string): Promise<string | undefined> {
@@ -230,7 +230,7 @@ export class StorageLayer implements StorageLayerProvider {
 
   async getMany(keys: string[], cache: boolean): Promise<StorageValue[]> {
     const result: StorageValue[] = []
-    const pending: Array<{ key: string, idx: number }> = []
+    const pending: Array<{ key: string; idx: number }> = []
 
     const preloadedPromises = keys.map(async (key, idx) => {
       if (this.#store.has(key)) {
@@ -243,7 +243,10 @@ export class StorageLayer implements StorageLayerProvider {
     })
 
     if (pending.length && this.#parent) {
-      const vals = await this.#parent.getMany(pending.map(p => p.key), false)
+      const vals = await this.#parent.getMany(
+        pending.map((p) => p.key),
+        false,
+      )
       vals.forEach((val, idx) => {
         if (cache) {
           this.#store.set(pending[idx].key, val)
@@ -326,9 +329,9 @@ export class StorageLayer implements StorageLayerProvider {
     }
 
     // value could be deleted on #parent and we have to exclude that. We have to load the values to check it
-    const values = await this.getMany(keys, false);
+    const values = await this.getMany(keys, false)
 
-    return keys.filter((_, i) => values[i] != StorageValueKind.Deleted)
+    return keys.filter((_, i) => values[i] !== StorageValueKind.Deleted)
   }
 
   /**

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -208,7 +208,10 @@ export class StorageLayer implements StorageLayerProvider {
     }
   }
 
-  #isDeleted(key: string): boolean {
+  async #isDeleted(key: string): Promise<boolean> {
+    if (this.#store.has(key)) {
+      return await this.#store.get(key) === StorageValueKind.Deleted
+    }
     return this.#deletedPrefix.some((dp) => key.startsWith(dp));
   }
 
@@ -217,7 +220,7 @@ export class StorageLayer implements StorageLayerProvider {
       return this.#store.get(key)
     }
 
-    if (this.#isDeleted(key)) {
+    if (this.#deletedPrefix.some((dp) => key.startsWith(dp))) {
       return StorageValueKind.Deleted
     }
 
@@ -326,7 +329,7 @@ export class StorageLayer implements StorageLayerProvider {
       const next = await this.findNextKey(prefix, startKey, undefined)
       if (!next) break
       startKey = next
-      if (this.#isDeleted(next)) continue
+      if (await this.#isDeleted(next)) continue
       keys.push(next)
     }
     return keys

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -208,12 +208,16 @@ export class StorageLayer implements StorageLayerProvider {
     }
   }
 
+  #isDeleted(key: string): boolean {
+    return this.#deletedPrefix.some((dp) => key.startsWith(dp));
+  }
+
   async get(key: string, cache: boolean): Promise<StorageValue | undefined> {
     if (this.#store.has(key)) {
       return this.#store.get(key)
     }
 
-    if (this.#deletedPrefix.some((dp) => key.startsWith(dp))) {
+    if (this.#isDeleted(key)) {
       return StorageValueKind.Deleted
     }
 
@@ -322,7 +326,7 @@ export class StorageLayer implements StorageLayerProvider {
       const next = await this.findNextKey(prefix, startKey, undefined)
       if (!next) break
       startKey = next
-      if ((await this.get(next, false)) === StorageValueKind.Deleted) continue
+      if (this.#isDeleted(next)) continue
       keys.push(next)
     }
     return keys

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -26,7 +26,7 @@ export interface StorageLayerProvider {
   /**
    * Get the value of many storage keys.
    */
-  getMany(key: string[], _cache: boolean): Promise<StorageValue[]>
+  getMany(keys: string[], _cache: boolean): Promise<StorageValue[]>
   /**
    * Get paged storage keys.
    */
@@ -63,9 +63,9 @@ export class RemoteStorageLayer implements StorageLayerProvider {
     return data ?? undefined
   }
 
-  async getMany(key: string[], _cache: boolean): Promise<StorageValue[]> {
+  async getMany(keys: string[], _cache: boolean): Promise<StorageValue[]> {
     const result: StorageValue[] = [];
-    let pending = key.map((key, idx) => ({ key, idx }));
+    let pending = keys.map((key, idx) => ({ key, idx }));
 
     if (this.#db) {
       const results = await Promise.all(
@@ -84,7 +84,7 @@ export class RemoteStorageLayer implements StorageLayerProvider {
     }
 
     if (pending.length) {
-      logger.trace({ at: this.#at, key }, "RemoteStorageLayer get");
+      logger.trace({ at: this.#at, keys }, "RemoteStorageLayer getMany");
       const data = await this.#api.getStorageBatch(
         "0x",
         pending.map(({ key }) => key as HexString),

--- a/packages/core/src/rpc/rpc-spec/storage-common.ts
+++ b/packages/core/src/rpc/rpc-spec/storage-common.ts
@@ -16,14 +16,11 @@ export async function getDescendantValues(
     pageSize: PAGE_SIZE,
   })
 
-  const items = await Promise.all(
-    keys.map((key) =>
-      block.get(key).then((value) => ({
-        key,
-        value,
-      })),
-    ),
-  )
+  const items = (await block.getMany(keys))
+    .map((value, idx) => ({
+      key: keys[idx],
+      value
+    }))
 
   if (keys.length < PAGE_SIZE) {
     return {

--- a/packages/core/src/rpc/rpc-spec/storage-common.ts
+++ b/packages/core/src/rpc/rpc-spec/storage-common.ts
@@ -16,11 +16,10 @@ export async function getDescendantValues(
     pageSize: PAGE_SIZE,
   })
 
-  const items = (await block.getMany(keys))
-    .map((value, idx) => ({
-      key: keys[idx],
-      value
-    }))
+  const items = (await block.getMany(keys)).map((value, idx) => ({
+    key: keys[idx],
+    value,
+  }))
 
   if (keys.length < PAGE_SIZE) {
     return {


### PR DESCRIPTION
I realised that when doing a `descendantValues` query with chopsticks, this one does a `state_getKeysPaged` followed by individual `state_getStorage` for each of the values. This makes those queries go quite slow.

When I implemented chainHead_v1, the `block` API didn't offer a way to query many values at once, so that's what I used.

This PR adds a `block.getMany()` to fetch multiple values at once. This had to be implemented on the storage-layer as well.

~~TODO review tests.~~ Please let me know if this feature is something you want as well, or if there are other implications I haven't thought of, since I haven't opened a discussion/issue before :'D

Kind-of related, this also allows to optimise certain operations that take a long time: I managed to speed up building the initial block from 12 seconds down to 4 seconds by pre-requesting the entries of `Paras.Heads`, `ParaInclusion.V1` and `CoretimeAssignmentProvider.CoreDescriptors`. Or on the staking SDK we're working on, changing the first era takes more than 2 hours to produce a block but I managed to reduce it to a minute and a half by carefully pre-requesting some Staking entries.  This obviously depends on the runtime, so I don't think it can be generalised, but opens the door to these kind of opportunities for specific use cases.