### PR TITLE
fix(chainHead_v1): bestBlock not announced after initialised

### DIFF
--- a/packages/core/src/rpc/rpc-spec/chainHead_v1.ts
+++ b/packages/core/src/rpc/rpc-spec/chainHead_v1.ts
@@ -88,6 +88,10 @@ export const chainHead_v1_follow: Handler<[boolean], string> = async (
       finalizedBlockHashes: [context.chain.head.hash],
       finalizedBlockRuntime: withRuntime ? await context.chain.head.runtimeVersion : null,
     })
+    callback({
+      event: 'bestBlockChanged',
+      bestBlockHash: context.chain.head.hash,
+    })
   })
 
   return id

--- a/packages/e2e/src/chainHead_v1.test.ts
+++ b/packages/e2e/src/chainHead_v1.test.ts
@@ -17,9 +17,15 @@ describe('chainHead_v1 rpc', async () => {
     const initialized = await nextValue()
     expect(initialized).toMatchSnapshot()
 
+    const [[firstBest]] = next.mock.calls.slice(1)
+    expect(firstBest).toEqual({
+      type: 'bestBlockChanged',
+      bestBlockHash: '0x6c74912ce35793b05980f924c3a4cdf1f96c66b2bedd0c7b7378571e60918145',
+    })
+
     const blockHash = await dev.newBlock()
 
-    const [[newBlock], [bestBlock], [finalized]] = next.mock.calls.slice(1)
+    const [[newBlock], [bestBlock], [finalized]] = next.mock.calls.slice(2)
 
     expect(newBlock).toEqual({
       type: 'newBlock',


### PR DESCRIPTION
According [to the spec](https://paritytech.github.io/json-rpc-interface-spec/api/chainHead_v1_follow.html#usage), on chainHead_v1_follow:

- Generates an `initialized` notification […]
- Generates one `newBlock` notification […] for each non-finalized block […]
- Then a `bestBlockChanged` notification

We don't have non-finalized blocks in chopsticks, but the `bestBlockChanged` notification should still be sent with the latest block. My original implementation was missing that point, and it breaks an assumption in PAPI in a specific case.

This PR just adds that missing `bestBlockChanged` notification.