### PR TITLE
Remove Sudo key from astar.yml

### DIFF
--- a/configs/astar.yml
+++ b/configs/astar.yml
@@ -8,8 +8,6 @@ db: ./db.sqlite
 runtime-log-level: 5
 
 import-storage:
-  Sudo:
-    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
   System:
     Account:
       -


### PR DESCRIPTION
The sudo pallet has been removed in the latest Astar `runtime-2000` upgrade.