### PR TITLE
fix: allow unsafeBlockHeight to override block number in storage

### DIFF
--- a/packages/core/src/blockchain/block-builder.ts
+++ b/packages/core/src/blockchain/block-builder.ts
@@ -160,10 +160,7 @@ const initNewBlock = async (
     if (unsafeBlockHeight !== undefined && blockNumber > head.number + 1) {
       const meta = await head.meta
       const value = meta.registry.createType('BlockNumber', blockNumber - 1).toU8a()
-      newBlock.pushStorageLayer().set(
-        compactHex(meta.query.system.number()),
-        u8aToHex(value),
-      )
+      newBlock.pushStorageLayer().set(compactHex(meta.query.system.number()), u8aToHex(value))
     }
 
     // initialize block


### PR DESCRIPTION
When `unsafeBlockHeight` is used, the block number in storage is overridden to ensure runtime validation for strictly increasing block numbers passes. This prevents issues when creating blocks with non-sequential numbers.