### PR TITLE
Update `relayParentDescendants` state roots in old `setValidationData`

### DIFF
--- a/packages/core/src/blockchain/inherent/parachain/validation-data.ts
+++ b/packages/core/src/blockchain/inherent/parachain/validation-data.ts
@@ -289,6 +289,27 @@ export class SetValidationData implements InherentProvider {
     if (argsLengh === 1) {
       // old version
 
+      let relayParentDescendants = extrinsic.relayParentDescendants
+      if (relayParentDescendants) {
+        let fakeParentHeader = relayParentDescendants[0]
+        if (fakeParentHeader) {
+          fakeParentHeader = {
+            ...fakeParentHeader,
+            number: relayParentNumber,
+            stateRoot: trieRootHash,
+          }
+          relayParentDescendants = [fakeParentHeader, ...relayParentDescendants.slice(1)]
+          let lastHeader: Header | undefined
+          for (const descendant of relayParentDescendants) {
+            if (lastHeader) {
+              descendant.parentHash = lastHeader.hash
+              descendant.number = lastHeader.number.toNumber() + 1
+            }
+            lastHeader = meta.registry.createType('Header', descendant) as Header
+          }
+        }
+      }
+
       const newData = {
         ...extrinsic,
         downwardMessages,
@@ -301,6 +322,7 @@ export class SetValidationData implements InherentProvider {
         relayChainState: {
           trieNodes: nodes,
         },
+        relayParentDescendants,
       } satisfies ValidationData
 
       const inherent = new GenericExtrinsic(meta.registry, meta.tx.parachainSystem.setValidationData(newData))


### PR DESCRIPTION
Basilisk (and any chain on old cumulus with `relayParentDescendants`) fails block building in Chopsticks:

```
Unable to verify provided relay parent descendants. expected_rp_descendants_num: 1
error: InvalidStateRoot { expected: 0x0c19d9c3..., found: 0xfef08584... }
```

XCM transfers never execute. Balances unchanged, tests fail.

## Root Cause

Basilisk runs old cumulus (1-arg `setValidationData`) but its blocks carry `relayParentDescendants` data. When Chopsticks builds a new block:

1. Reads parent block's [validation data](https://github.com/AcalaNetwork/chopsticks/blob/4cb9e8e8d189fcd3db710b0dfabdb434e064b898/packages/core/src/blockchain/inherent/parachain/validation-data.ts#L53-L65) (includes `relayParentDescendants`)
2. Rebuilds relay chain state trie -> new `trieRootHash` ([line 283](https://github.com/AcalaNetwork/chopsticks/blob/4cb9e8e8d189fcd3db710b0dfabdb434e064b898/packages/core/src/blockchain/inherent/parachain/validation-data.ts#L283))
3. Updates `relayParentStorageRoot = trieRootHash` ([line 298](https://github.com/AcalaNetwork/chopsticks/blob/4cb9e8e8d189fcd3db710b0dfabdb434e064b898/packages/core/src/blockchain/inherent/parachain/validation-data.ts#L298))
4. **Leaves `relayParentDescendants[0].stateRoot` untouched** (old value). No update in old branch.
5. Runtime panics: descendant state root != relayParentStorageRoot

The [new 2-arg API branch](https://github.com/AcalaNetwork/chopsticks/blob/4cb9e8e8d189fcd3db710b0dfabdb434e064b898/packages/core/src/blockchain/inherent/parachain/validation-data.ts#L312-L329) already updates descendant state roots. The [old 1-arg branch](https://github.com/AcalaNetwork/chopsticks/blob/4cb9e8e8d189fcd3db710b0dfabdb434e064b898/packages/core/src/blockchain/inherent/parachain/validation-data.ts#L289-L308) doesn't.

### Validation

Run `yarn test bifrostKusama.basilisk.xcm` in [polkadot-ecosystem-tests](https://github.com/open-web3-stack/polkadot-ecosystem-tests) before the fix. Block building fails with `InvalidStateRoot`. After the fix is applied to Chopsticks in `polkadot-ecosystem-tests/node-modules`, it passes.

Query Basilisk's actual validation data (latest block as of 2026-04-22):

```bash
$ node check-basilisk.js
Latest block: 13930029
args: 1
descendants: 2
descendants[0].stateRoot: 0x26159e249...
relayParentStorageRoot: 0x26159e249...
match: true
```

<details>
<summary>check-basilisk.js</summary>

```javascript
import { ApiPromise, WsProvider } from '@polkadot/api';

async function main() {
  const api = await ApiPromise.create({ provider: new WsProvider('wss://rpc.basilisk.cloud') });
  const header = await api.rpc.chain.getHeader();
  const blockNum = header.number.toNumber();
  console.log('Latest block:', blockNum);
  
  const hash = await api.rpc.chain.getBlockHash(blockNum);
  const block = await api.rpc.chain.getBlock(hash);
  
  for (const tx of block.block.extrinsics) {
    if (tx.method.section === 'parachainSystem' && tx.method.method === 'setValidationData') {
      const json = tx.method.args[0].toJSON();
      console.log('args:', Object.keys(tx.method.argsDef).length);
      console.log('descendants:', json.relayParentDescendants?.length ?? 0);
      
      if (json.relayParentDescendants?.length > 0) {
        const desc0 = json.relayParentDescendants[0].stateRoot;
        const relay = json.validationData.relayParentStorageRoot;
        console.log('descendants[0].stateRoot:', desc0.substring(0, 12) + '...');
        console.log('relayParentStorageRoot:', relay.substring(0, 12) + '...');
        console.log('match:', desc0 === relay);
      }
      break;
    }
  }
  
  await api.disconnect();
}

main().catch(console.error);
```

</details>

In the original block, the state roots match. But when Chopsticks builds a new block, it:
1. Rebuilds the trie with new entries (HRMP messages, etc)
2. Gets a different `trieRootHash`
3. Updates `relayParentStorageRoot = trieRootHash`
4. **Doesn't update `descendants[0].stateRoot`**
5. Runtime sees `descendants[0].stateRoot != relayParentStorageRoot` -> panic


This only happens in Basilisk because it is the only chain on the old API with populated descendants.
| Chain | API | Descendants | Status |
|---|---|---|---|
| Basilisk | 1-arg | 2 | fails |
| Karura | 1-arg | 0 | passes |
| AssetHub | 2-arg | 2 | passes |
| BifrostKusama | 2-arg | 0 | passes |

## Fix

Apply the same descendant state root update logic from the 2-arg branch to the [1-arg branch](https://github.com/AcalaNetwork/chopsticks/blob/4cb9e8e8d189fcd3db710b0dfabdb434e064b898/packages/core/src/blockchain/inherent/parachain/validation-data.ts#L289-L308) in `validation-data.ts`:

```typescript
// Before rebuilding newData, update descendants
let relayParentDescendants = extrinsic.relayParentDescendants
if (relayParentDescendants) {
  let fakeParentHeader = relayParentDescendants[0]
  if (fakeParentHeader) {
    fakeParentHeader = {
      ...fakeParentHeader,
      number: relayParentNumber,
      stateRoot: trieRootHash,  // <-- key fix
    }
    relayParentDescendants = [fakeParentHeader, ...relayParentDescendants.slice(1)]
    let lastHeader: Header | undefined
    for (const descendant of relayParentDescendants) {
      if (lastHeader) {
        descendant.parentHash = lastHeader.hash
        descendant.number = lastHeader.number.toNumber() + 1
      }
      lastHeader = meta.registry.createType('Header', descendant) as Header
    }
  }
}
```

Then include `relayParentDescendants` in the `newData` object.

## Validation

Tested with [polkadot-ecosystem-tests](https://github.com/open-web3-stack/polkadot-ecosystem-tests):
- `bifrostKusama.basilisk.xcm.test.ts`: 2/2 passing (was 0/2)
- `basilisk.karura.xcm.test.ts`: 4/4 passing (was 0/4)