### PR TITLE
Enforce `getKeysPaged` page size limits in storage layers

### DIFF
--- a/packages/core/src/blockchain/get-keys-paged.test.ts
+++ b/packages/core/src/blockchain/get-keys-paged.test.ts
@@ -153,6 +153,19 @@ describe('getKeysPaged', () => {
     ])
   })
 
+  it('storage layer enforces the remote page size limit', async () => {
+    const layer = new StorageLayer(storageLayer)
+    layer.setAll([['0x1111111111111111111111111111111111111111111111111111111111111111_00', '0x00']])
+
+    await expect(
+      layer.getKeysPaged(
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+        1001,
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+      ),
+    ).rejects.toThrow('pageSize must be less or equal to 1000')
+  })
+
   it('updated values', async () => {
     const layer2 = new StorageLayer(storageLayer)
     layer2.setAll([['0x1111111111111111111111111111111111111111111111111111111111111111_04', '0x04']])

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -342,6 +342,8 @@ export class StorageLayer implements StorageLayerProvider {
   }
 
   async getKeysPaged(prefix: string, pageSize: number, startKey: string): Promise<string[]> {
+    if (pageSize > BATCH_SIZE) throw new Error(`pageSize must be less or equal to ${BATCH_SIZE}`)
+
     if (!startKey || startKey === '0x') {
       startKey = prefix
     }


### PR DESCRIPTION
## Summary
- Add the `BATCH_SIZE` limit check to `StorageLayer.getKeysPaged` so overlay storage matches `RemoteStorageLayer` behavior.
- Cover the regression with a unit test that verifies an imported storage overlay rejects `pageSize > 1000`.

## Testing
- `yarn vitest run packages/core/src/blockchain/get-keys-paged.test.ts`
- `yarn lint`

closes #1025