### PR TITLE
Performance and correctness improvements for test-runner consumers

### DIFF
--- a/packages/chopsticks/package.json
+++ b/packages/chopsticks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"bin": "./chopsticks.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks-core",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -8,7 +8,13 @@ import type { Database } from './database.js'
 import type { ChainProperties, Header, SignedBlock } from './index.js'
 import { prefixedChildKey, splitChildKey, stripChildPrefix } from './utils/index.js'
 
-const CACHEABLE_METHODS = new Set(['system_chain', 'system_properties', 'system_name', 'chain_getBlockHash', 'chain_getHeader'])
+const CACHEABLE_METHODS = new Set([
+  'system_chain',
+  'system_properties',
+  'system_name',
+  'chain_getBlockHash',
+  'chain_getHeader',
+])
 
 /**
  * API class. Calls provider to get on-chain data.

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -4,8 +4,11 @@ import type { ExtDef } from '@polkadot/types/extrinsic/signedExtensions/types'
 import type { HexString } from '@polkadot/util/types'
 import _ from 'lodash'
 
+import type { Database } from './database.js'
 import type { ChainProperties, Header, SignedBlock } from './index.js'
 import { prefixedChildKey, splitChildKey, stripChildPrefix } from './utils/index.js'
+
+const CACHEABLE_METHODS = new Set(['system_chain', 'system_properties', 'system_name', 'chain_getBlockHash', 'chain_getHeader'])
 
 /**
  * API class. Calls provider to get on-chain data.
@@ -24,6 +27,8 @@ export class Api {
   #ready: Promise<void> | undefined
   #chain: Promise<string> | undefined
   #chainProperties: Promise<ChainProperties> | undefined
+  #db?: Database
+  #scope?: string
 
   readonly signedExtensions: ExtDef
 
@@ -34,6 +39,25 @@ export class Api {
   constructor(provider: ProviderInterface, signedExtensions?: ExtDef) {
     this.#provider = provider
     this.signedExtensions = signedExtensions || {}
+  }
+
+  setDb(db: Database, scope: string) {
+    this.#db = db
+    this.#scope = scope
+  }
+
+  async #cachedSend<T>(method: string, params: unknown[], isCacheable?: boolean): Promise<T> {
+    if (this.#db?.queryRpcCall && this.#scope && CACHEABLE_METHODS.has(method)) {
+      const key = JSON.stringify(params)
+      const cached = await this.#db.queryRpcCall(this.#scope, method, key)
+      if (cached !== null) return JSON.parse(cached) as T
+      this.#apiHooks?.fetching?.()
+      const result = await this.#provider.send<T>(method, params, isCacheable)
+      await this.#db.saveRpcCall?.(this.#scope, method, key, JSON.stringify(result))
+      return result
+    }
+    this.#apiHooks?.fetching?.()
+    return this.#provider.send(method, params, isCacheable)
   }
 
   async disconnect() {
@@ -84,19 +108,19 @@ export class Api {
   }
 
   async getSystemName() {
-    return this.send<string>('system_name', [])
+    return this.#cachedSend<string>('system_name', [])
   }
 
   async getSystemProperties() {
-    return this.send<ChainProperties>('system_properties', [])
+    return this.#cachedSend<ChainProperties>('system_properties', [])
   }
 
   async getSystemChain() {
-    return this.send<string>('system_chain', [])
+    return this.#cachedSend<string>('system_chain', [])
   }
 
   async getBlockHash(blockNumber?: number) {
-    return this.send<HexString | null>(
+    return this.#cachedSend<HexString | null>(
       'chain_getBlockHash',
       Number.isInteger(blockNumber) ? [blockNumber] : [],
       !!blockNumber,
@@ -104,7 +128,7 @@ export class Api {
   }
 
   async getHeader(hash?: string) {
-    return this.send<Header | null>('chain_getHeader', hash ? [hash] : [], !!hash)
+    return this.#cachedSend<Header | null>('chain_getHeader', hash ? [hash] : [], !!hash)
   }
 
   async getFinalizedHead() {

--- a/packages/core/src/blockchain/block-builder.ts
+++ b/packages/core/src/blockchain/block-builder.ts
@@ -384,6 +384,41 @@ export const buildBlock = async (
   return [finalBlock, pendingExtrinsics]
 }
 
+export type DryRunResult = {
+  outcome: ApplyExtrinsicResult
+  storageDiff: [HexString, HexString | null][]
+}
+
+/**
+ * Dry-run a batch of extrinsics against the same initialized block.
+ *
+ * Core_initialize_block and the inherents are executed once. Each extrinsic
+ * is then applied on a temporary storage layer that is pushed before the call
+ * and popped after, so no extrinsic side-effects leak into the next.
+ *
+ * Caveat: because account nonces revert with each pop, all extrinsics must be
+ * pre-signed with the same base nonce.
+ */
+export const dryRunExtrinsicsAmortized = async (
+  head: Block,
+  inherentProviders: InherentProvider[],
+  extrinsics: HexString[],
+  params: BuildBlockParams,
+): Promise<DryRunResult[]> => {
+  const registry = await head.registry
+  const header = await newHeader(head)
+  const { block: newBlock } = await initNewBlock(head, header, inherentProviders, params)
+  const results: DryRunResult[] = []
+  for (const extrinsic of extrinsics) {
+    newBlock.pushStorageLayer()
+    const resp = await newBlock.call('BlockBuilder_apply_extrinsic', [extrinsic])
+    const outcome = registry.createType<ApplyExtrinsicResult>('ApplyExtrinsicResult', resp.result)
+    results.push({ outcome, storageDiff: resp.storageDiff })
+    newBlock.popStorageLayer()
+  }
+  return results
+}
+
 export const dryRunExtrinsic = async (
   head: Block,
   inherentProviders: InherentProvider[],

--- a/packages/core/src/blockchain/block.ts
+++ b/packages/core/src/blockchain/block.ts
@@ -215,6 +215,22 @@ export class Block {
   }
 
   /**
+   * Truncate the storage layer stack back to a target depth.
+   *
+   * Used by snapshot-restore mechanisms to undo accumulated dev.setStorage
+   * calls when reverting to a previously captured state, without losing the
+   * underlying block.
+   */
+  resetStorageLayers(targetCount: number): void {
+    while (this.#storages.length > targetCount) this.#storages.pop()
+  }
+
+  /** The current depth of the storage layer stack. */
+  get storageLayerCount(): number {
+    return this.#storages.length
+  }
+
+  /**
    * Get storage diff.
    */
   async storageDiff(): Promise<Record<HexString, HexString | null>> {

--- a/packages/core/src/blockchain/head-state.ts
+++ b/packages/core/src/blockchain/head-state.ts
@@ -56,17 +56,36 @@ export class HeadState {
 
     const diff = await this.#head.storageDiff()
 
+    const newValues: Record<string, string | null> = { ...diff }
+    const watchedKeys = new Set<string>()
+    for (const [keys] of Object.values(this.#storageListeners)) {
+      for (const key of keys) watchedKeys.add(key)
+    }
+    for (const key of watchedKeys) {
+      if (newValues[key] === undefined && this.#oldValues[key] !== undefined) {
+        newValues[key] = (await head.get(key)) ?? null
+      }
+    }
+
     for (const [keys, cb] of Object.values(this.#storageListeners)) {
-      const changed = keys.filter((key) => diff[key]).map((key) => [key, diff[key]] as [string, string | null])
-      if (changed.length > 0) {
+      const changes: [string, string | null][] = []
+      for (const key of keys) {
+        if (newValues[key] === undefined) continue
+        if (newValues[key] !== this.#oldValues[key]) {
+          changes.push([key, newValues[key]])
+        }
+      }
+      if (changes.length > 0) {
         try {
-          await cb(head, changed)
+          await cb(head, changes)
         } catch (error) {
           logger.error(error, 'setHead storage diff callback error')
         }
       }
     }
 
-    Object.assign(this.#oldValues, diff)
+    for (const [key, value] of Object.entries(newValues)) {
+      this.#oldValues[key] = value
+    }
   }
 }

--- a/packages/core/src/blockchain/index.ts
+++ b/packages/core/src/blockchain/index.ts
@@ -16,7 +16,7 @@ import { OffchainWorker } from '../offchain.js'
 import { compactHex } from '../utils/index.js'
 import type { RuntimeVersion } from '../wasm-executor/index.js'
 import { Block } from './block.js'
-import { dryRunExtrinsic, dryRunInherents } from './block-builder.js'
+import { dryRunExtrinsic, dryRunExtrinsicsAmortized, dryRunInherents } from './block-builder.js'
 import { HeadState } from './head-state.js'
 import type { InherentProvider } from './inherent/index.js'
 import type { StorageValue } from './storage-layer.js'
@@ -453,6 +453,29 @@ export class Blockchain {
     const { result, storageDiff } = await dryRunExtrinsic(head, this.#inherentProviders, extrinsic, params)
     const outcome = registry.createType<ApplyExtrinsicResult>('ApplyExtrinsicResult', result)
     return { outcome, storageDiff }
+  }
+
+  /**
+   * Dry-run a batch of extrinsics in block `at`, amortizing block initialization
+   * across the whole batch. Each extrinsic is applied independently — its storage
+   * changes do not accumulate into subsequent extrinsics.
+   */
+  async dryRunExtrinsicsAmortized(
+    extrinsics: HexString[],
+    at?: HexString,
+  ): Promise<{ outcome: ApplyExtrinsicResult; storageDiff: [HexString, HexString | null][] }[]> {
+    await this.api.isReady
+    const head = at ? await this.getBlock(at) : this.head
+    if (!head) {
+      throw new Error(`Cannot find block ${at}`)
+    }
+    const params = {
+      transactions: [],
+      downwardMessages: [],
+      upwardMessages: [],
+      horizontalMessages: {},
+    }
+    return dryRunExtrinsicsAmortized(head, this.#inherentProviders, extrinsics, params)
   }
 
   /**

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -137,8 +137,19 @@ export class RemoteStorageLayer implements StorageLayerProvider {
       return this.#api.getKeysPaged(prefix, pageSize, startKey, this.#at)
     }
 
+    const startKeyEqualsPrefix = startKey === prefix
+    if (this.#db?.queryPagedKeys && startKeyEqualsPrefix) {
+      const cached = await this.#db.queryPagedKeys(this.#at, prefix as HexString)
+      if (cached) {
+        isChild
+          ? this.#defaultChildKeyCache.feed([startKey, ...cached] as HexString[])
+          : this.#keyCache.feed([startKey, ...cached] as HexString[])
+      }
+    }
+
     let batchComplete = false
     const keysPaged: string[] = []
+    const allFetchedKeys: HexString[] = []
     while (keysPaged.length < pageSize) {
       const nextKey = isChild
         ? await this.#defaultChildKeyCache.next(startKey as HexString)
@@ -172,16 +183,9 @@ export class RemoteStorageLayer implements StorageLayerProvider {
       }
 
       if (this.#db) {
-        // filter out keys that are not in the db]
-        const newBatch: HexString[] = []
-
-        for (const key of batch) {
-          const res = await this.#db.queryStorage(this.#at, key)
-          if (res) {
-            continue
-          }
-          newBatch.push(key)
-        }
+        const newBatch: HexString[] = await Promise.all(
+          batch.map((key) => this.#db!.queryStorage(this.#at, key).then((r) => (r ? null : key))),
+        ).then((rs) => rs.filter((k): k is HexString => k !== null))
 
         if (newBatch.length > 0) {
           // batch fetch storage values and save to db, they may be used later
@@ -191,8 +195,17 @@ export class RemoteStorageLayer implements StorageLayerProvider {
             }
           })
         }
+
+        if (startKeyEqualsPrefix) {
+          allFetchedKeys.push(...(batch as HexString[]))
+        }
       }
     }
+
+    if (this.#db?.savePagedKeys && startKeyEqualsPrefix && allFetchedKeys.length > 0) {
+      await this.#db.savePagedKeys(this.#at, prefix as HexString, allFetchedKeys)
+    }
+
     return keysPaged
   }
 }

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -126,8 +126,14 @@ export class RemoteStorageLayer implements StorageLayerProvider {
     const isChild = isPrefixedChildKey(prefix as HexString)
     const minPrefixLen = isChild ? CHILD_PREFIX_LENGTH : PREFIX_LENGTH
 
-    // can't handle keyCache without prefix
-    if (prefix === startKey || prefix.length < minPrefixLen || startKey.length < minPrefixLen) {
+    // KeyCache groups by the first `minPrefixLen` chars; it cannot correctly answer queries
+    // whose prefix is longer than that grouping width, so proxy directly to upstream.
+    if (
+      prefix.length < minPrefixLen ||
+      startKey.length < minPrefixLen ||
+      prefix.length > minPrefixLen ||
+      startKey.length > minPrefixLen
+    ) {
       return this.#api.getKeysPaged(prefix, pageSize, startKey, this.#at)
     }
 

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -151,9 +151,11 @@ export class RemoteStorageLayer implements StorageLayerProvider {
     }
 
     const startKeyEqualsPrefix = startKey === prefix
+    let cachedKeys: HexString[] | undefined
     if (this.#db?.queryPagedKeys && startKeyEqualsPrefix) {
       const cached = await this.#db.queryPagedKeys(this.#at, prefix as HexString)
       if (cached) {
+        cachedKeys = cached
         isChild
           ? this.#defaultChildKeyCache.feed([startKey, ...cached] as HexString[])
           : this.#keyCache.feed([startKey, ...cached] as HexString[])
@@ -161,8 +163,10 @@ export class RemoteStorageLayer implements StorageLayerProvider {
     }
 
     let batchComplete = false
+    let fetchedNewKeys = false
     const keysPaged: string[] = []
-    const allFetchedKeys: HexString[] = []
+    // Seed with cached keys so a cache-hit-then-extend doesn't truncate the persisted set.
+    const allFetchedKeys: HexString[] = cachedKeys ? [...cachedKeys] : []
     while (keysPaged.length < pageSize) {
       const nextKey = isChild
         ? await this.#defaultChildKeyCache.next(startKey as HexString)
@@ -211,11 +215,12 @@ export class RemoteStorageLayer implements StorageLayerProvider {
 
         if (startKeyEqualsPrefix) {
           allFetchedKeys.push(...(batch as HexString[]))
+          fetchedNewKeys = true
         }
       }
     }
 
-    if (this.#db?.savePagedKeys && startKeyEqualsPrefix && allFetchedKeys.length > 0) {
+    if (this.#db?.savePagedKeys && startKeyEqualsPrefix && fetchedNewKeys) {
       await this.#db.savePagedKeys(this.#at, prefix as HexString, allFetchedKeys)
     }
 

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -47,6 +47,7 @@ export class RemoteStorageLayer implements StorageLayerProvider {
   readonly #db: Database | undefined
   readonly #keyCache = new KeyCache(PREFIX_LENGTH)
   readonly #defaultChildKeyCache = new KeyCache(CHILD_PREFIX_LENGTH)
+  readonly #inflight = new Map<string, Promise<StorageValue>>()
 
   constructor(api: Api, at: HexString, db: Database | undefined) {
     this.#api = api
@@ -65,10 +66,22 @@ export class RemoteStorageLayer implements StorageLayerProvider {
         return res.value ?? undefined
       }
     }
+
+    const inflight = this.#inflight.get(key)
+    if (inflight) return inflight
+
     logger.trace({ at: this.#at, key }, 'RemoteStorageLayer get')
-    const data = await this.#api.getStorage(key, this.#at)
-    this.#db?.saveStorage(this.#at as HexString, key as HexString, data)
-    return data ?? undefined
+    const fetch = this.#api
+      .getStorage(key, this.#at)
+      .then((data) => {
+        this.#db?.saveStorage(this.#at as HexString, key as HexString, data)
+        return data ?? undefined
+      })
+      .finally(() => {
+        this.#inflight.delete(key)
+      })
+    this.#inflight.set(key, fetch)
+    return fetch
   }
 
   async getMany(keys: string[], _cache: boolean): Promise<StorageValue[]> {

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -27,4 +27,8 @@ export declare class Database {
   saveStorage: (blockHash: HexString, key: HexString, value: HexString | null) => Promise<void>
   saveStorageBatch?: (entries: KeyValueEntry[]) => Promise<void>
   queryStorage: (blockHash: HexString, key: HexString) => Promise<KeyValueEntry | null>
+  queryPagedKeys?: (blockHash: HexString, prefix: HexString) => Promise<HexString[] | null>
+  savePagedKeys?: (blockHash: HexString, prefix: HexString, keys: HexString[]) => Promise<void>
+  queryRpcCall?: (scope: string, method: string, params: string) => Promise<string | null>
+  saveRpcCall?: (scope: string, method: string, params: string, result: string) => Promise<void>
 }

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -51,6 +51,11 @@ export const processOptions = async (options: SetupOptions) => {
   // setup api hooks
   api.onFetching(options.hooks?.apiFetching)
 
+  if (options.db) {
+    const scope = typeof options.endpoint === 'string' ? options.endpoint : JSON.stringify(options.endpoint ?? '')
+    api.setDb(options.db, scope)
+  }
+
   await api.isReady
 
   let blockHash: string

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks-db",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/db/src/base-sql.ts
+++ b/packages/db/src/base-sql.ts
@@ -2,7 +2,7 @@ import type { BlockEntry, Database, KeyValueEntry } from '@acala-network/chopsti
 import type { HexString } from '@polkadot/util/types'
 import type { DataSource } from 'typeorm'
 
-import { BlockEntity, KeyValuePair } from './db/entities.js'
+import { BlockEntity, KeyValuePair, PagedKeys, RpcCall } from './db/entities.js'
 
 export abstract class BaseSqlDatabase implements Database {
   abstract datasource: Promise<DataSource>
@@ -78,5 +78,27 @@ export abstract class BaseSqlDatabase implements Database {
   async queryStorage(blockHash: HexString, key: HexString): Promise<KeyValueEntry | null> {
     const db = await this.datasource
     return db.getRepository(KeyValuePair).findOne({ where: { blockHash, key } })
+  }
+
+  async queryPagedKeys(blockHash: HexString, prefix: HexString): Promise<HexString[] | null> {
+    const db = await this.datasource
+    const row = await db.getRepository(PagedKeys).findOne({ where: { blockHash, prefix } })
+    return row ? JSON.parse(row.keys) : null
+  }
+
+  async savePagedKeys(blockHash: HexString, prefix: HexString, keys: HexString[]): Promise<void> {
+    const db = await this.datasource
+    await db.getRepository(PagedKeys).upsert({ blockHash, prefix, keys: JSON.stringify(keys) }, ['blockHash', 'prefix'])
+  }
+
+  async queryRpcCall(scope: string, method: string, params: string): Promise<string | null> {
+    const db = await this.datasource
+    const row = await db.getRepository(RpcCall).findOne({ where: { scope, method, params } })
+    return row?.result ?? null
+  }
+
+  async saveRpcCall(scope: string, method: string, params: string, result: string): Promise<void> {
+    const db = await this.datasource
+    await db.getRepository(RpcCall).upsert({ scope, method, params, result }, ['scope', 'method', 'params'])
   }
 }

--- a/packages/db/src/db/entities.ts
+++ b/packages/db/src/db/entities.ts
@@ -1,6 +1,19 @@
 import type { BlockEntry, KeyValueEntry } from '@acala-network/chopsticks-core'
 import { EntitySchema } from 'typeorm'
 
+export type PagedKeysEntry = {
+  blockHash: string
+  prefix: string
+  keys: string
+}
+
+export type RpcCallEntry = {
+  scope: string
+  method: string
+  params: string
+  result: string
+}
+
 export const KeyValuePair = new EntitySchema<KeyValueEntry>({
   name: 'KeyValuePair',
   columns: {
@@ -48,6 +61,51 @@ export const BlockEntity = new EntitySchema<BlockEntry>({
     storageDiff: {
       type: 'simple-json',
       nullable: true,
+    },
+  },
+})
+
+export const PagedKeys = new EntitySchema<PagedKeysEntry>({
+  name: 'PagedKeys',
+  columns: {
+    blockHash: {
+      primary: true,
+      type: 'varchar',
+      nullable: false,
+    },
+    prefix: {
+      primary: true,
+      type: 'varchar',
+      nullable: false,
+    },
+    keys: {
+      type: 'text',
+      nullable: false,
+    },
+  },
+})
+
+export const RpcCall = new EntitySchema<RpcCallEntry>({
+  name: 'RpcCall',
+  columns: {
+    scope: {
+      primary: true,
+      type: 'varchar',
+      nullable: false,
+    },
+    method: {
+      primary: true,
+      type: 'varchar',
+      nullable: false,
+    },
+    params: {
+      primary: true,
+      type: 'varchar',
+      nullable: false,
+    },
+    result: {
+      type: 'text',
+      nullable: false,
     },
   },
 })

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks-testing",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks-utils",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -240,13 +240,19 @@ export function defer<T>() {
 export const sendTransaction = async (tx: Promise<SubmittableExtrinsic<'promise'>>) => {
   const signed = await tx
   const deferred = defer<Codec[]>()
-  await signed.send((status) => {
+  // Swallow rejections that arrive after the deferred has already settled (the
+  // subscription continues to fire callbacks after isInBlock/isFinalized).
+  deferred.promise.catch(() => {})
+  let unsub: (() => void) | undefined
+  unsub = await signed.send((status) => {
     logger.debug({ status: status.status.toHuman() }, 'Transaction status')
     if (status.isInBlock || status.isFinalized) {
       deferred.resolve(status.events)
+      if (unsub) unsub()
     }
     if (status.isError) {
       deferred.reject(status.status)
+      if (unsub) unsub()
     }
   })
 


### PR DESCRIPTION
Closes AcalaNetwork/chopsticks#1027.

## Why

[polkadot-ecosystem-tests](https://github.com/open-web3-stack/polkadot-ecosystem-tests) (PET) drives Chopsticks against live RPCs to run end-to-end suites against Polkadot, Kusama and their parachains. Profiling that workload (see [open-web3-stack/polkadot-ecosystem-tests#606](https://github.com/open-web3-stack/polkadot-ecosystem-tests/issues/606), authored by @ggwpez with Claude) surfaced two classes of issues that this PR addresses:

1. **Avoidable RPC traffic.** Chain-identification and storage-key enumeration calls were re-issued every run, in-flight `getStorage` requests for the same `(blockHash, key)` were not coalesced, and the `getKeysPaged` short-circuit bypassed both in-memory and on-disk caches.
2. **Missing or wrong correctness primitives for test-runner consumers.** PET needs to (a) restore a network to a previously-saved snapshot mid-suite, (b) be told when subscribed keys revert across that restore, (c) submit transactions without seeing late post-finalization status callbacks turn into unhandled rejections, and (d) dry-run a batch of extrinsics without paying block-initialization cost per extrinsic.

## Layout

11 commits. Performance commits cache or coalesce; correctness commits add API surface or fix a subscriber bug.

### Performance

| # | Commit | Touches |
|---|---|---|
| 1 | `Cache deterministic chain/system RPC calls to disk` | `packages/db`, `packages/core/src/api.ts`, `packages/core/src/database.ts`, `packages/core/src/setup.ts` |
| 2 | `Refine getKeysPaged guard to bypass cache for off-grid prefixes` | `packages/core/src/blockchain/storage-layer.ts` |
| 3 | `Cache getKeysPaged results to disk; skip prefetch on cache hit` | `packages/core/src/blockchain/storage-layer.ts` |
| 4 | `Preserve cached keys when extending getKeysPaged batch` | `packages/core/src/blockchain/storage-layer.ts` |
| 5 | `Coalesce concurrent in-flight RemoteStorageLayer.get requests` | `packages/core/src/blockchain/storage-layer.ts` |

### Correctness / new API

| # | Commit | Touches |
|---|---|---|
| 6 | `Expose Block.resetStorageLayers and storageLayerCount` | `packages/core/src/blockchain/block.ts` |
| 7 | `Notify storage subscribers for keys reverted by setHead` | `packages/core/src/blockchain/head-state.ts` |
| 8 | `Unsubscribe and swallow late rejections in sendTransaction` | `packages/utils/src/index.ts` |
| 9 | `Add dryRunExtrinsicsAmortized for amortized batch dry-run` | `packages/core/src/blockchain/block-builder.ts`, `packages/core/src/blockchain/index.ts` |

The 10th commit is a biome formatting pass with no logic changes. The 11th bumps all published packages to **v1.4.0**.

## Notes for reviewers

- **§1**: two new TypeORM entities (`PagedKeys`, `RpcCall`). `RpcCall.scope` is set to the endpoint URL because consumers can share `DB_PATH` across chains; without scoping `system_chain` would collide between e.g. polkadot/kusama. Only deterministic methods route through the cache (`system_chain`, `system_properties`, `system_name`, `chain_getBlockHash`, `chain_getHeader`); `chain_getFinalizedHead` is intentionally untouched.
- **§2**: `KeyCache` groups entries by the first `PREFIX_LENGTH` (66) hex chars. The previous guard returned upstream early when `prefix === startKey`, which also masked a latent correctness bug: when the caller-supplied prefix is longer than 66 chars (smoldot's `clear_prefix` does this), the cache would otherwise return a key that shares the truncated 66-char head but not the full prefix, tripping smoldot's `key.starts_with(req.prefix())` assertion in `runtime_call.rs`. The new guard bypasses the cache exactly when prefix or startKey is off the cache's grouping width, and lets the common 66-char case fall through to be cached. Found and fixed against `trace-call.test.ts > Karura`.
- **§3**: the post-batch storage prefetch loop (1000 sequential SQLite point lookups + a fire-and-forget upstream batch fetch) now only runs on cache miss, not hit. The miss path is also parallelised via `Promise.all`. Adds `queryPagedKeys` / `savePagedKeys` to the `Database` interface; only seeded when `startKey === prefix`.
- **§4**: fixes a cache-corruption edge case in §3: if the caller's `pageSize` forces an upstream fetch after a disk-cache hit, `allFetchedKeys` is pre-seeded with the cached keys so `savePagedKeys` writes the full union rather than overwriting with only the newly fetched batch.
- **§5**: per-`RemoteStorageLayer` `Map<key, Promise<StorageValue>>` to coalesce concurrent `get(key)` calls for the same `(blockHash, key)`. Cleared on settle via `.finally`. Per-process only; does not replace the on-disk cache.
- **§6**: two new `Block` methods. `resetStorageLayers(targetCount)` truncates the `#storages` stack to a target depth; `get storageLayerCount()` reads its current size. Enables PET's mid-suite snapshot restore without leaking `setStorage` mutations across tests.
- **§7**: previously, listeners were only told about keys present in the new head's storage diff. After a backward `setHead` (e.g. snapshot restore), keys that the more recent block touched were absent from the older block's diff and so subscribers were never told their values had been reverted. Polkadot.js's `WsProvider` retained stale post-mutation values and routed subsequent `state_queryStorageAt` calls against the wrong block. Refactored so all callbacks see a consistent post-update view.
- **§8**: `signed.send` keeps firing status callbacks after `isInBlock`/`isFinalized`. A subsequent `isError` callback (e.g. a tx-pool rejection arriving after the block was already produced) called `deferred.reject` on the already-settled promise, producing an unhandled rejection. Now: explicit `unsub()` after a terminal status, plus a no-op `.catch` on the deferred to swallow late settles. `unsub` is declared `let` before the `await signed.send(...)` so the callback's reference resolves correctly without a TDZ violation.
- **§9**: `Core_initialize_block` and the inherents are executed once for the whole batch. Each extrinsic is applied on a temporary push/pop storage layer so its side-effects do not accumulate into subsequent calls. Returns `{ outcome: ApplyExtrinsicResult; storageDiff }[]`; callers decode events from the `storageDiff` at the system events key. Exposed as both a standalone `dryRunExtrinsicsAmortized` export from `block-builder.ts` and as `Blockchain.dryRunExtrinsicsAmortized`. **Caveat**: all extrinsics must be pre-signed with the same base nonce, as account state (including nonce) reverts with each pop. Measured ~10× speedup on the inner loop vs. one `newBlock()` per extrinsic (per open-web3-stack/polkadot-ecosystem-tests#606).

## Deferred from open-web3-stack/polkadot-ecosystem-tests#606

- **`Replace sqlite3 with better-sqlite3`**: works in isolation but exposes a timing-sensitive interaction with polkadot-api's chainHead observable client (regresses `chainHead_v1 closestDescendantMerkleValue`). Worth landing separately after that's understood.