### PR TITLE
Forward `rpcTimeout` from `SetupOption` to chopsticks config

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -37,8 +37,10 @@ export type SetupOption = {
   wasmOverride?: string
   /** Path to database file */
   db?: string
-  /** Connection timeout in milliseconds */
+  /** Timeout (ms) for the test-side WsProvider connecting to the in-process chopsticks server */
   timeout?: number
+  /** Timeout (ms) for chopsticks' own upstream RPC client (chopsticks → upstream/proxy). Forwarded as `rpc-timeout` in the chopsticks config */
+  rpcTimeout?: number
   /** Host address to bind the server to */
   host?: string
   /** Port number to bind the server to */
@@ -77,6 +79,7 @@ export const createConfig = ({
   wasmOverride,
   db,
   timeout,
+  rpcTimeout,
   host,
   port,
   maxMemoryBlockCount,
@@ -100,6 +103,7 @@ export const createConfig = ({
     db,
     'wasm-override': wasmOverride,
     timeout,
+    'rpc-timeout': rpcTimeout,
     resume: resume ?? false,
     'allow-unresolved-imports': allowUnresolvedImports,
     'process-queued-messages': processQueuedMessages,


### PR DESCRIPTION
## Motivation

`chopsticks-utils` test-setup code creates two distinct `WsProvider` instances:

1. A **test-side** `WsProvider` returned by `setupContextWithConfig`, used by test code to talk to the in-process chopsticks server (`ws://localhost:<chopsticks-port>`). Its timeout is controlled by `SetupOption.timeout`, which is destructured out of the config and passed to the constructor.
2. An **upstream** `WsProvider` constructed inside `chopsticks-core/setup.ts`, used by chopsticks itself to talk to the upstream chain (or to a proxy like Subway sitting in front of it). Its timeout is controlled by chopsticks' `rpc-timeout` config field, which `chopsticks` reads at boot and forwards into `chopsticks-core`'s `setup({ ..., rpcTimeout })`.

There is no `SetupOption` field that maps to the upstream `rpc-timeout`, so it always defaults to 60s regardless of what the consumer sets.

For test suites that need to extend that limit (e.g. for an XCM-Transact storage query against a slow public RPC), there is currently no way to do so short of running chopsticks as a separate process with `--rpc-timeout`. The motivating case is one such timeout seen on Acala in [polkadot-fellows/runtimes#1180](https://github.com/polkadot-fellows/runtimes/pull/1180) / [open-web3-stack/polkadot-ecosystem-tests#621](https://github.com/open-web3-stack/polkadot-ecosystem-tests/pull/621).

## Change

- Add `rpcTimeout?: number` to `SetupOption`, with a JSDoc that disambiguates it from `timeout`.
- Forward it as `'rpc-timeout': rpcTimeout` in the config object emitted by `createConfig`.
- Tighten `timeout`'s docstring to clarify which `WsProvider` it actually governs.

Trivial diff in one file. No behaviour change when `rpcTimeout` is unset.