### PR TITLE
Support Bulletin chain (`pallet-transaction-storage`)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/smoldot"]
 	path = vendor/smoldot
-	url = https://github.com/smol-dot/smoldot.git
+	url = https://github.com/paritytech/smoldot.git

--- a/executor/Cargo.lock
+++ b/executor/Cargo.lock
@@ -63,6 +63,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +443,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +471,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -581,7 +605,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -922,6 +946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,11 +1189,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smoldot"
-version = "0.21.0"
+version = "1.1.3"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
+ "base32",
  "base64",
  "bip39",
  "blake2-rfc",
@@ -1174,6 +1205,7 @@ dependencies = [
  "ed25519-zebra",
  "either",
  "event-listener",
+ "fastbloom",
  "fnv",
  "futures-lite",
  "futures-util",

--- a/executor/package.json
+++ b/executor/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@acala-network/chopsticks-executor",
 	"description": "Chopsticks executor",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"license": "Apache-2.0",
 	"type": "module",
 	"repository": {

--- a/packages/chopsticks/package.json
+++ b/packages/chopsticks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"bin": "./chopsticks.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks-core",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/core/src/blockchain/inherent/index.ts
+++ b/packages/core/src/blockchain/inherent/index.ts
@@ -6,6 +6,7 @@ import { SetBabeRandomness } from './parachain/babe-randomness.js'
 import { SetNimbusAuthorInherent } from './parachain/nimbus-author-inherent.js'
 import { SetValidationData } from './parachain/validation-data.js'
 import { SetTimestamp } from './timestamp.js'
+import { SetTransactionStorageProof } from './transaction-storage.js'
 
 export interface InherentProvider {
   createInherents(newBlock: Block, params: BuildBlockParams): Promise<HexString[]>
@@ -17,4 +18,5 @@ export const inherentProviders = [
   new ParaInherentEnter(),
   new SetNimbusAuthorInherent(),
   new SetBabeRandomness(),
+  new SetTransactionStorageProof(),
 ]

--- a/packages/core/src/blockchain/inherent/transaction-storage.ts
+++ b/packages/core/src/blockchain/inherent/transaction-storage.ts
@@ -1,0 +1,28 @@
+import { GenericExtrinsic } from '@polkadot/types'
+import type { HexString } from '@polkadot/util/types'
+import { compactHex } from '../../utils/index.js'
+import type { Block } from '../block.js'
+import type { InherentProvider } from './index.js'
+
+export class SetTransactionStorageProof implements InherentProvider {
+  async createInherents(newBlock: Block): Promise<HexString[]> {
+    const parent = await newBlock.parentBlock
+    if (!parent) throw new Error('parent block not found')
+    const meta = await parent.meta
+    if (!meta.tx.transactionStorage?.applyBlockInherents) {
+      return []
+    }
+
+    // The runtime's on_finalize asserts ProofChecked was set when stored
+    // transactions exist at (block - RetentionPeriod). Generating a real
+    // proof requires the original chunk data Chopsticks doesn't have, so
+    // we force the flag via storage override instead.
+    if (meta.query.transactionStorage?.proofChecked) {
+      const key = compactHex(meta.query.transactionStorage.proofChecked())
+      newBlock.pushStorageLayer().set(key, '0x01')
+    }
+
+    const inherent = new GenericExtrinsic(meta.registry, meta.tx.transactionStorage.applyBlockInherents(null))
+    return [inherent.toHex()]
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks-db",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks-testing",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acala-network/chopsticks-utils",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"author": "Acala Developers <hello@acala.network>",
 	"license": "Apache-2.0",
 	"type": "module",


### PR DESCRIPTION
## Summary

Chopsticks could not fork Bulletin on Paseo. Three things were broken.

**1. Missing inherent.** Bulletin requires a `transactionStorage.applyBlockInherents` call every block. Chopsticks did not produce one. The runtime panics in `on_finalize` if it is absent. Added an inherent provider that creates the call and forces the `ProofChecked` flag in storage — Chopsticks cannot generate real storage proofs because it does not have the underlying chunk data.

**2. `ext_trie_blake2_256_verify_proof` not implemented.** The runtime calls this to verify Merkle proofs for stored transactions. smoldot had it stubbed with a panic. Implemented all four `verify_proof` variants using smoldot existing `trie::proof_decode`.

**3. `ext_transaction_index_index` reads params wrong.** The handler assumed param 0 is an i64 pointer+size pair. It is actually three i32s. Panics on `unreachable!()` the moment a `storeWithCidConfig` extrinsic triggers transaction indexing. Same bug in `ext_transaction_index_renew`. Both are no-ops — just removed the bad param reads.

Fixes 2 and 3 are in the smoldot submodule bump, pending merge of https://github.com/paritytech/smoldot/pull/3276. CI will fail until that lands.

## Testing

Validated against `wss://paseo-bulletin-next-rpc.polkadot.io` (Paseo Bulletin Next, para 1501):

- `dev_newBlock`: 7+ consecutive blocks, zero errors
- Submitted and dispatched representative Bulletin extrinsics through the tx pool:
  - `sudo(authorizeAccount)` -> `AccountAuthorized`
  - `store` -> `Stored` + content hash + CID
  - `storeWithCidConfig` (SHA2-256, DAG-PB) -> `Stored` + CID
  - `storeWithCidConfig` (Blake2b256, raw) -> `Stored` + CID
  - `forceRenew(Position)` -> `Renewed`
  - `sudo(authorizePreimage)` -> `PreimageAuthorized`
  - `sudo(refreshAccountAuthorization)` -> `AccountAuthorizationRefreshed`
  - `sudo(refreshPreimageAuthorization)` -> `PreimageAuthorizationRefreshed`
- `run-block` replay: all extrinsics (including signed `storeWithCidConfig`) execute without crashes. `finalize_block` still fails on replay due to a state-availability limitation (the inherent proof re-verification needs historical `Transactions` data that is not accessible through RPC-backed state).