### PR TITLE
test(e2e): replace Zeitgeist with Asset Hub for horizontal connection

### DIFF
--- a/packages/e2e/src/__snapshots__/connect-horizontal.test.ts.snap
+++ b/packages/e2e/src/__snapshots__/connect-horizontal.test.ts.snap
@@ -12,19 +12,4 @@ exports[`connectHorizontal > connectHorizontal opens channel > system events 1`]
 ]
 `;
 
-exports[`connectHorizontal > connectHorizontal opens channel > system events 2`] = `
-[
-  {
-    "data": {
-      "error": "TooExpensive",
-      "messageHash": "(hash)",
-      "weight": {
-        "proofSize": 0,
-        "refTime": 600000000,
-      },
-    },
-    "method": "Fail",
-    "section": "xcmpQueue",
-  },
-]
-`;
+exports[`connectHorizontal > connectHorizontal opens channel > system events 2`] = `[]`;

--- a/packages/e2e/src/__snapshots__/connect-horizontal.test.ts.snap
+++ b/packages/e2e/src/__snapshots__/connect-horizontal.test.ts.snap
@@ -12,4 +12,22 @@ exports[`connectHorizontal > connectHorizontal opens channel > system events 1`]
 ]
 `;
 
-exports[`connectHorizontal > connectHorizontal opens channel > system events 2`] = `[]`;
+exports[`connectHorizontal > connectHorizontal opens channel > system events 2`] = `
+[
+  {
+    "data": {
+      "id": "(hash)",
+      "origin": {
+        "Sibling": 2000,
+      },
+      "success": false,
+      "weightUsed": {
+        "proofSize": "(rounded 7100)",
+        "refTime": "(rounded 94000000)",
+      },
+    },
+    "method": "Processed",
+    "section": "messageQueue",
+  },
+]
+`;

--- a/packages/e2e/src/connect-horizontal.test.ts
+++ b/packages/e2e/src/connect-horizontal.test.ts
@@ -13,21 +13,23 @@ describe('connectHorizontal', () => {
         Account: [[[alice.address], { providers: 1, data: { free: 1000e12 } }]],
       },
     })
-    const zeitgeist = await setupContext({
-      endpoint: ['wss://zeitgeist.api.onfinality.io/public-ws'],
-      blockNumber: 5084336,
+
+    // Use a second parachain (Polkadot Asset Hub)
+    const assetHub = await setupContext({
+      endpoint: 'wss://asset-hub-polkadot-rpc.n.dwellir.com',
+      blockNumber: 1000000,
       db: !process.env.RUN_TESTS_WITHOUT_DB ? 'e2e-tests-db.sqlite' : undefined,
     })
 
     await connectHorizontal({
       2000: acala.chain,
-      2092: zeitgeist.chain,
+      1000: assetHub.chain,
     })
 
     await acala.dev.newBlock()
-    await zeitgeist.dev.newBlock()
+    await assetHub.dev.newBlock()
 
-    // This tx will be sent to Zeitgeist and fail but it's fine for this test as we only want to test the connection
+    // This tx will be sent to Asset Hub and fail but it's fine for this test as we only want to test the connection
     await acala.api.tx.xTokens
       .transfer(
         {
@@ -40,7 +42,7 @@ describe('connectHorizontal', () => {
             interior: {
               X2: [
                 {
-                  Parachain: 2092,
+                  Parachain: 1000,
                 },
                 {
                   AccountId32: {
@@ -60,10 +62,10 @@ describe('connectHorizontal', () => {
     await acala.dev.newBlock()
     await checkSystemEvents(acala, 'xcmpQueue', 'XcmpMessageSent').toMatchSnapshot()
 
-    await zeitgeist.dev.newBlock()
-    await checkSystemEvents(zeitgeist, 'xcmpQueue', 'Fail').toMatchSnapshot()
+    await assetHub.dev.newBlock()
+    await checkSystemEvents(assetHub, 'xcmpQueue', 'Fail').toMatchSnapshot()
 
     await acala.teardown()
-    await zeitgeist.teardown()
+    await assetHub.teardown()
   })
 })

--- a/packages/e2e/src/connect-horizontal.test.ts
+++ b/packages/e2e/src/connect-horizontal.test.ts
@@ -17,7 +17,7 @@ describe('connectHorizontal', () => {
     // Use a second parachain (Polkadot Asset Hub)
     const assetHub = await setupContext({
       endpoint: 'wss://asset-hub-polkadot-rpc.n.dwellir.com',
-      blockNumber: 1000000,
+      blockNumber: 16540000,
       db: !process.env.RUN_TESTS_WITHOUT_DB ? 'e2e-tests-db.sqlite' : undefined,
     })
 
@@ -63,7 +63,7 @@ describe('connectHorizontal', () => {
     await checkSystemEvents(acala, 'xcmpQueue', 'XcmpMessageSent').toMatchSnapshot()
 
     await assetHub.dev.newBlock()
-    await checkSystemEvents(assetHub, 'xcmpQueue', 'Fail').toMatchSnapshot()
+    await checkSystemEvents(assetHub, 'messageQueue').toMatchSnapshot()
 
     await acala.teardown()
     await assetHub.teardown()


### PR DESCRIPTION
Removed Zeitgeist configuration files and updated the `connect-horizontal` E2E test to use Polkadot Asset Hub (parachain ID 1000) instead of Zeitgeist (parachain ID 2092).