### PR TITLE
fix(core): serve getKeysPaged scan continuations from the KeyCache again

### DIFF
--- a/packages/core/src/blockchain/get-keys-paged.test.ts
+++ b/packages/core/src/blockchain/get-keys-paged.test.ts
@@ -543,3 +543,77 @@ describe('RemoteStorageLayer KeyCache', () => {
     for (const key of got) expect(key.startsWith(accountA)).toBe(true)
   })
 })
+
+// @xlc's (maintainer, #1055) reported correctness hole: an on-grid PREFIX (exactly minPrefixLen=66)
+// combined with a startKey drawn from a DIFFERENT 66-char group. The pre-fix guard passed both of these
+// (prefix.length === 66, startKey.length >= 66), so the request reached the cache — and KeyCache.next()
+// picks its range from the first 66 chars of the *startKey*, ignoring the method's prefix, so it returned a
+// key belonging to the other group instead of []. (The `off-grid prefix` test above never covered this: it
+// uses a prefix LONGER than 66, which the guard already proxies.)
+describe('RemoteStorageLayer KeyCache — cross-prefix startKey (#1055)', () => {
+  const hash = '0x1111111111111111111111111111111111111111111111111111111111111111'
+  // Two DIFFERENT exactly-66-char (on-grid) prefixes.
+  const prefixA = '0x1111111111111111111111111111111111111111111111111111111111111111'
+  const prefixB = '0x2222222222222222222222222222222222222222222222222222222222222222'
+  const keys = [`${prefixA}01`, `${prefixA}02`, `${prefixB}01`, `${prefixB}02`]
+
+  const makeLayer = () => {
+    const getKeysPaged = vi.fn(async (p: string, pageSize: number, startKey: string) =>
+      keys.filter((k) => k.startsWith(p) && k > startKey).slice(0, pageSize),
+    )
+    const api = { getKeysPaged } as unknown as Api
+    return { layer: new RemoteStorageLayer(api, hash, undefined), getKeysPaged }
+  }
+
+  it('does not answer prefixA from a startKey that belongs to prefixB', async () => {
+    const { layer } = makeLayer()
+
+    // Warm prefixB's group.
+    await layer.getKeysPaged(prefixB, 10, prefixB)
+
+    // Ask for prefixA, but hand it a startKey from prefixB's group. No key starting with prefixA is
+    // greater than `${prefixB}01`, so the only correct answer is []. The buggy cache returns `${prefixB}02`.
+    const got = await layer.getKeysPaged(prefixA, 10, `${prefixB}01`)
+    expect(got).toEqual([])
+    for (const key of got) expect(key.startsWith(prefixA)).toBe(true)
+  })
+})
+
+// Quantifies the 1.4.0 regression this PR reverses: a single storage-map scan walked one page at a time
+// must cost a small CONSTANT of upstream round-trips (the map is fetched into the KeyCache in one batch and
+// every continuation is served from cache), NOT ~one round-trip per key.
+describe('RemoteStorageLayer KeyCache — continuation upstream call count (#1055)', () => {
+  const hash = '0x1111111111111111111111111111111111111111111111111111111111111111'
+  const prefix = '0x3333333333333333333333333333333333333333333333333333333333333333'
+  const K = 50
+  const keys = Array.from({ length: K }, (_, i) => `${prefix}${i.toString(16).padStart(4, '0')}`)
+
+  const makeLayer = () => {
+    const getKeysPaged = vi.fn(async (p: string, pageSize: number, startKey: string) =>
+      keys.filter((k) => k.startsWith(p) && k > startKey).slice(0, pageSize),
+    )
+    const api = { getKeysPaged } as unknown as Api
+    return { layer: new RemoteStorageLayer(api, hash, undefined), getKeysPaged }
+  }
+
+  it(`scans ${K} keys page-by-page (pageSize 1) with a constant number of upstream calls, not ~${K}`, async () => {
+    const { layer, getKeysPaged } = makeLayer()
+
+    // Walk the whole map one key at a time, exactly as findNextKey does.
+    const scanned: string[] = []
+    let startKey = prefix
+    for (;;) {
+      const page = await layer.getKeysPaged(prefix, 1, startKey)
+      if (page.length === 0) break
+      scanned.push(page[0]!)
+      startKey = page[0]!
+    }
+
+    // Correctness: we saw every key, in order.
+    expect(scanned).toEqual(keys)
+
+    // Perf: the K continuations add zero upstream calls; the whole scan costs a small constant independent of
+    // K. The 1.4.0/1.5.0 regression bypasses the cache on every continuation, costing ~K instead.
+    expect(getKeysPaged.mock.calls.length).toBeLessThan(K)
+  })
+})

--- a/packages/core/src/blockchain/get-keys-paged.test.ts
+++ b/packages/core/src/blockchain/get-keys-paged.test.ts
@@ -494,3 +494,52 @@ describe('getKeysPaged', () => {
     expect(evenKeys, 'evenKeys').toEqual(allKeys.filter((x) => x.startsWith(evenPrefix)))
   })
 })
+
+describe('RemoteStorageLayer KeyCache', () => {
+  const hash = '0x1111111111111111111111111111111111111111111111111111111111111111'
+  // A prefix exactly PREFIX_LENGTH (66) chars wide — the width the KeyCache groups on.
+  const prefix = '0x2222222222222222222222222222222222222222222222222222222222222222'
+  // Two "accounts" under it, i.e. off-grid prefixes: longer than the grouping width, as a double-map's
+  // partial key (or smoldot's clear_prefix) produces.
+  const accountA = `${prefix}aaaa`
+  const accountB = `${prefix}bbbb`
+  const keys = [`${accountA}01`, `${accountA}02`, `${accountB}01`, `${accountB}02`]
+
+  const makeLayer = () => {
+    const getKeysPaged = vi.fn(async (p: string, pageSize: number, startKey: string) =>
+      keys.filter((k) => k.startsWith(p) && k > startKey).slice(0, pageSize),
+    )
+    const api = { getKeysPaged } as unknown as Api
+    return { layer: new RemoteStorageLayer(api, hash, undefined), getKeysPaged }
+  }
+
+  it('serves scan continuations from the KeyCache instead of the remote', async () => {
+    const { layer, getKeysPaged } = makeLayer()
+
+    // First page: startKey === prefix. This is the call that populates the cache.
+    expect(await layer.getKeysPaged(prefix, 1, prefix)).toEqual([keys[0]])
+    const afterFirstPage = getKeysPaged.mock.calls.length
+
+    // Continuations. Their startKey is a full-length key by construction, and the KeyCache already covers
+    // this range — so they must NOT cost an upstream round-trip.
+    expect(await layer.getKeysPaged(prefix, 1, keys[0])).toEqual([keys[1]])
+    expect(await layer.getKeysPaged(prefix, 1, keys[1])).toEqual([keys[2]])
+    expect(await layer.getKeysPaged(prefix, 1, keys[2])).toEqual([keys[3]])
+
+    expect(getKeysPaged.mock.calls.length).toBe(afterFirstPage)
+  })
+
+  it('never answers an off-grid prefix from the KeyCache', async () => {
+    const { layer } = makeLayer()
+
+    // Warm the 66-char group with a contiguous run spanning both accounts.
+    await layer.getKeysPaged(prefix, 10, prefix)
+
+    // `accountA` is longer than the grouping width. Its last key is `${accountA}02`, so the correct answer
+    // here is []. A cache that grouped only on the truncated 66-char head would hand back `${accountB}01`,
+    // which does not start with the requested prefix.
+    const got = await layer.getKeysPaged(accountA, 5, `${accountA}02`)
+    expect(got).toEqual([])
+    for (const key of got) expect(key.startsWith(accountA)).toBe(true)
+  })
+})

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -147,7 +147,14 @@ export class RemoteStorageLayer implements StorageLayerProvider {
     // `startKey` is a different matter: every CONTINUATION of a scan carries a full-length storage key by
     // construction, and serving those from the cache is precisely what the cache is for. Bailing out on a long
     // `startKey` makes each continuation page an upstream round-trip.
-    if (prefix.length !== minPrefixLen || startKey.length < minPrefixLen) {
+    //
+    // But a long `startKey` is only cache-safe when it belongs to the SAME group as `prefix`. `KeyCache.next()`
+    // derives its range from the first `minPrefixLen` chars of the `startKey` alone and never checks the result
+    // against `prefix`, so a `startKey` from a different `minPrefixLen`-char group would be answered from that
+    // other group's range — returning a key that does not start with `prefix`. `!startKey.startsWith(prefix)`
+    // proxies those cross-group requests to upstream; genuine continuations (`startKey.startsWith(prefix)` by
+    // construction) still hit the cache. (Reported by @xlc on #1055.)
+    if (prefix.length !== minPrefixLen || startKey.length < minPrefixLen || !startKey.startsWith(prefix)) {
       return this.#api.getKeysPaged(prefix, pageSize, startKey, this.#at)
     }
 

--- a/packages/core/src/blockchain/storage-layer.ts
+++ b/packages/core/src/blockchain/storage-layer.ts
@@ -139,14 +139,15 @@ export class RemoteStorageLayer implements StorageLayerProvider {
     const isChild = isPrefixedChildKey(prefix as HexString)
     const minPrefixLen = isChild ? CHILD_PREFIX_LENGTH : PREFIX_LENGTH
 
-    // KeyCache groups by the first `minPrefixLen` chars; it cannot correctly answer queries
-    // whose prefix is longer than that grouping width, so proxy directly to upstream.
-    if (
-      prefix.length < minPrefixLen ||
-      startKey.length < minPrefixLen ||
-      prefix.length > minPrefixLen ||
-      startKey.length > minPrefixLen
-    ) {
+    // KeyCache groups by the first `minPrefixLen` chars; it cannot correctly answer queries whose PREFIX is
+    // off that grouping width, so those are proxied directly to upstream (a longer prefix would otherwise match
+    // on the truncated head and return keys that do not start with the requested prefix — smoldot's
+    // `clear_prefix` asserts `key.starts_with(prefix)`).
+    //
+    // `startKey` is a different matter: every CONTINUATION of a scan carries a full-length storage key by
+    // construction, and serving those from the cache is precisely what the cache is for. Bailing out on a long
+    // `startKey` makes each continuation page an upstream round-trip.
+    if (prefix.length !== minPrefixLen || startKey.length < minPrefixLen) {
       return this.#api.getKeysPaged(prefix, pageSize, startKey, this.#at)
     }
 


### PR DESCRIPTION
Fixes #1054.

## What

Since #1028 (released in 1.4.0), `RemoteStorageLayer.getKeysPaged` bypasses the `KeyCache` on **every continuation page of a storage-map scan**, so each continuation costs an upstream RPC round-trip.

#1028 refined the guard to bypass the cache for **off-grid prefixes** — prefixes longer than the cache's `minPrefixLen` grouping width, which the cache cannot answer correctly (it matches on the truncated head and can return keys that don't start with the requested prefix, tripping smoldot's `key.starts_with(prefix)` assertion in `clear_prefix` paths).

**That correctness fix is right, and this PR keeps it.** I verified the bug it fixed is real: on 1.3.1, an off-grid scan on a double map returned 5 keys, **all 5 outside the requested prefix** (it leaked the next map entry's keys). The `prefix` check is doing real work.

The problem is that the same guard also bypasses the cache when the **`startKey`** is off-grid:

```js
prefix.length > minPrefixLen || startKey.length > minPrefixLen
```

**A scan continuation's `startKey` is a full-length storage key by construction** — it is the last key of the previous page. So this bypasses the cache on *every continuation of every scan*, and the cache path becomes reachable only when `startKey === prefix`, i.e. only for the very first page. 1.4.0 therefore populates the `KeyCache` (and the new on-disk `paged_keys` table) with a map's whole key list, then never consults either again for the rest of the scan.

This inverts #1028's own goal — polkadot-ecosystem-tests#606 profiled the old `prefix === startKey` early-return precisely because it cost "one upstream round-trip (~120 ms)" per call.

## Why it amplifies so hard

`Block.getKeysPaged` → `block.storage.getKeysPaged(...)`. With a storage overlay (i.e. **any config using `import-storage`**), `block.storage` is a `StorageLayer`, whose `getKeysPaged` **walks `findNextKey` one key at a time** → `RemoteStorageLayer.getKeysPaged(prefix, 1, startKey)`. On 1.4+, that makes **each key its own upstream `state_getKeysPaged`**.

Enumerating a **single storage map** (1,431 keys) through such a fork, counted on the wire between chopsticks and the upstream endpoint, on clean unmodified installs:

| chopsticks | keys | wall clock | upstream `state_getKeysPaged` |
|---|---|---|---|
| **1.3.1** | 1,431 | **3.5 s** | **4** |
| **1.5.0** | 1,431 | **342.4 s** | **1,431** |

One upstream round-trip per key — a ~98× slowdown and ~358× the RPC traffic. Full repro in #1054.

## The fix

Restrict the bypass to off-grid **prefixes**:

```diff
-    if (
-      prefix.length < minPrefixLen ||
-      startKey.length < minPrefixLen ||
-      prefix.length > minPrefixLen ||
-      startKey.length > minPrefixLen
-    ) {
+    if (prefix.length !== minPrefixLen || startKey.length < minPrefixLen) {
       return this.#api.getKeysPaged(prefix, pageSize, startKey, this.#at)
     }
```

Safe in both directions:
- an off-grid **prefix** is still proxied, so the cache can never *answer* one (#1028's fix preserved);
- `feed()` is only reachable from the cache path, so an off-grid batch can never *poison* the grouped range either.

## Tests

Two tests added to `packages/core/src/blockchain/get-keys-paged.test.ts`:

1. **`serves scan continuations from the KeyCache instead of the remote`** — asserts a continuation within an already-cached range issues **no** upstream call. **This fails on `master`** with `expected 4 to be 1` (one first page + three continuations, each proxied), and passes with the fix.
2. **`never answers an off-grid prefix from the KeyCache`** — warms the grouped range, then asks for a continuation past an off-grid prefix's last key; asserts `[]` rather than the next entry's keys. This guards #1028's correctness fix against regression.

All pre-existing tests in the file still pass (10/10 with the fix). `biome check` clean on both files.

Verified end-to-end on the real workload: with this change, 1.5.0 goes from ~400 s / 2,468 upstream calls to **31.0 s / 122 upstream calls** on the read that motivated the report, still authors blocks, and still returns identical state.

> Note: `yarn lint` fails in my environment on `packages/core/src/wasm-executor/index.ts` (`Cannot find module '@acala-network/chopsticks-executor'`) because I did not build the Rust executor. It reproduces identically on pristine `master`, so it is unrelated to this change.